### PR TITLE
PR for Release 0.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
           # NOTE: suppressions paths must be absolute — ASan/UBSan resolve
           # relative paths against the test binary's cwd, not the repo root.
           export ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:suppressions=${GITHUB_WORKSPACE}/build-aux/asan_suppressions.txt"
+          export LSAN_OPTIONS="suppressions=${GITHUB_WORKSPACE}/build-aux/lsan_suppressions.txt"
           export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:suppressions=${GITHUB_WORKSPACE}/build-aux/ubsan_suppressions.txt"
           meson test -C build --print-errorlogs
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
 MEOW MENU DEVELOPMENT
+0.5.3 (2026-05-29)
+=====
+- enable keyboard navigation
+- add keyboard docs in GitHub Pages
+
 0.5.2 (2026-05-27)
 =====
 - Enable GitHub Pages

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ project that originated as a fork of [Whisker Menu](https://gitlab.xfce.org/pane
 and keeps the familiar panel-launcher feel while bringing a cleaner modern
 look and more customization options.
 
+**Fully keyboard-driven** — every zone (search, results, sidebar, mode
+switch, session buttons) is reachable without the mouse. See
+[Keyboard navigation](docs/keyboard-navigation.md) for the complete
+shortcut reference.
+
 
 
 ---

--- a/build-aux/asan_suppressions.txt
+++ b/build-aux/asan_suppressions.txt
@@ -15,10 +15,6 @@
 # suppression. Add entries only when a real third-party issue is identified
 # and tracked.
 #
-# FcInit — fontconfig global state is intentionally never freed at process
-# exit (it is a per-process singleton). LSan triggers when Pango initialises
-# a font backend in a GLib thread spawned by gtk_init_check(). No code
-# defect; suppressed to keep sanitizer signal clean.
-# Upstream acknowledgement: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/78
-# Added: 2026-05-28
-leak:FcInit
+# NOTE: `leak:` rules belong in the LSan suppressions file
+# (build-aux/lsan_suppressions.txt), not here. ASan's parser rejects
+# unknown rule types and aborts before any test runs.

--- a/build-aux/asan_suppressions.txt
+++ b/build-aux/asan_suppressions.txt
@@ -14,3 +14,11 @@
 # This file is intentionally empty on day one. CI must run green without any
 # suppression. Add entries only when a real third-party issue is identified
 # and tracked.
+#
+# FcInit — fontconfig global state is intentionally never freed at process
+# exit (it is a per-process singleton). LSan triggers when Pango initialises
+# a font backend in a GLib thread spawned by gtk_init_check(). No code
+# defect; suppressed to keep sanitizer signal clean.
+# Upstream acknowledgement: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/78
+# Added: 2026-05-28
+leak:FcInit

--- a/build-aux/lsan_suppressions.txt
+++ b/build-aux/lsan_suppressions.txt
@@ -1,0 +1,18 @@
+# LeakSanitizer suppressions for the MeowMenu CI `sanitizers` job.
+#
+# Scoping rules (see spec.md Edge Cases §266, data-model.md §170):
+#   - Suppressions MUST be per-function or per-symbol.
+#   - Whole-file or whole-library production suppressions are FORBIDDEN.
+#   - Every suppression MUST cite the upstream bug it tracks and the date
+#     it was added. Stale entries without a tracking link are removed at
+#     the next audit.
+#
+# Format: one `leak:<symbol-or-regex>` rule per line.
+#
+# FcInit — fontconfig global state is intentionally never freed at process
+# exit (it is a per-process singleton). LSan triggers when Pango initialises
+# a font backend in a GLib thread spawned by gtk_init_check(). No code
+# defect; suppressed to keep sanitizer signal clean.
+# Upstream acknowledgement: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/78
+# Added: 2026-05-28
+leak:FcInit

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,4 +50,4 @@ Then right-click the panel → **Add New Items** → **MeowMenu**.
 | XFCE panel native | ✓ | ✓ |
 | Keyboard navigation | ✓ | ✓ |
 
-→ [Installation](installation) · [Presets](presets) · [Configuration](configuration) · [FAQ](faq)
+→ [Installation](installation) · [Presets](presets) · [Configuration](configuration) · [Keyboard navigation](keyboard-navigation) · [FAQ](faq)

--- a/docs/keyboard-navigation.md
+++ b/docs/keyboard-navigation.md
@@ -1,0 +1,105 @@
+---
+title: Keyboard navigation
+layout: default
+nav_order: 6
+has_children: false
+---
+
+# Keyboard navigation
+
+MeowMenu is fully keyboard-driven. Every visible area — search box,
+results, sidebar categories, the Apps/Places switch, and the session
+buttons — can be reached and operated without touching the mouse.
+
+This page lists the shortcuts that work on every preset and on both
+X11 and Wayland.
+
+## Quick reference
+
+| Key                  | Effect                                                                  |
+|----------------------|-------------------------------------------------------------------------|
+| Type any letter      | Starts (or extends) a search query — focus jumps to the search box.     |
+| Space                | While searching, inserts a space into the query (it does not "click").  |
+| `Backspace`          | Removes the last character from the query. Stops at the empty query.    |
+| `Enter`              | Launches the highlighted item; on the search box, launches the first match. |
+| `Tab` / `Shift+Tab`  | Cycles focus between zones: Search → Results → Sidebar → Apps/Places → Session buttons (and back). |
+| `↑` / `↓`            | Moves the selection one row up or down inside the current list.         |
+| `Page Up` / `Page Down` | Moves the selection by one visible page inside the list.             |
+| `Home` / `End`       | Jumps to the first / last item inside the current list or sidebar.      |
+| `←` / `→`            | Inside the sidebar: exits to the results. Inside the results: exits to the sidebar (only while not searching). |
+| `Esc`                | Closes context menus, then cancels a resize, then clears the query, then closes the menu. |
+| `Shift+F10` or `Menu`| Opens the context menu for the highlighted launcher.                    |
+
+## Tab order
+
+Pressing `Tab` walks the menu in a fixed logical order:
+
+1. **Search box** — always the first stop.
+2. **Results list** — current category or search results.
+3. **Sidebar** — category buttons. Skipped while a query is active.
+4. **Apps / Places switch** — only present when Places is enabled.
+5. **Session buttons** — lock, logout, suspend, etc.
+
+`Shift+Tab` walks the same cycle in reverse. Zones that are hidden by
+the current preset (for example, no profile bar) are skipped silently.
+
+## Inside each zone
+
+**Sidebar.** `↑` / `↓` (or `←` / `→` when the sidebar is horizontal)
+move between categories and wrap at the ends. `Home` / `End` jump to
+the first / last category. The arrow that points toward the results
+exits the sidebar; the opposite arrow does nothing.
+
+**Results list.** `↑` / `↓` move row by row (no wrap). `Page Up` /
+`Page Down` move one screenful at a time. `Home` / `End` jump to the
+first / last item. `Enter` launches.
+
+**Apps / Places switch.** Any arrow key flips to the other side. The
+arrow that points toward the search box does **not** flip — use `Tab`
+to leave. `Space` is treated as a normal space character when you are
+typing, so it does not toggle the switch.
+
+**Session buttons.** `←` / `→` move between visible buttons (no wrap).
+`Enter` (or `Space`) activates the focused button. `↑` / `↓` do
+nothing inside this strip.
+
+## The `Esc` ladder
+
+A single press peels exactly one layer, in this strict order:
+
+1. If a right-click context menu is open, close just that menu.
+2. Otherwise, if a window resize is in progress, cancel the resize and
+   restore the previous size.
+3. Otherwise, if the search box contains text, clear the query.
+4. Otherwise, close the menu.
+
+`Backspace` and `Delete` never close the menu — only `Esc` (or the
+configured global toggle shortcut) does.
+
+## Type-to-search
+
+You can start typing at any time. Letters, digits, punctuation, and
+emoji are all routed into the search box, regardless of which zone
+holds focus. Keys that do not produce text (`Shift`, `Ctrl`, function
+keys, arrow keys, `Insert`, `Delete`…) are passed through to the
+focused widget unchanged.
+
+The redirect respects active input-method composition: a half-typed
+Japanese / Chinese / Korean character is finished where it was
+started, not in the search box.
+
+## RTL languages
+
+The logical Tab order (Search → Results → Sidebar → Switch → Buttons)
+is the same in RTL locales such as Arabic and Hebrew. Only the visual
+direction of the sidebar-exit arrow is mirrored, so the arrow always
+points the right way on screen.
+
+## Wayland note
+
+On Wayland the layer-shell preset keeps the menu open even when focus
+moves to another window briefly (for example, when a notification
+takes focus). Close the menu the way you opened it (the global
+shortcut) or press `Esc`.
+
+[Back to top](#keyboard-navigation)

--- a/panel-plugin/core/window-keyboard.cpp
+++ b/panel-plugin/core/window-keyboard.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "window-keyboard.h"
+
+#include <gdk/gdkkeysyms.h>
+
+namespace WhiskerMenu
+{
+namespace Keyboard
+{
+
+bool zone_active(Zone z, VisibilityMask mask, MenuState state)
+{
+	bool visible = false;
+	switch (z)
+	{
+	case Zone::Search:  visible = mask.search;  break;
+	case Zone::Results: visible = mask.results; break;
+	case Zone::Sidebar: visible = mask.sidebar; break;
+	case Zone::Mode:    visible = mask.mode;    break;
+	case Zone::Profile: visible = mask.profile; break;
+	}
+	if (!visible)
+		return false;
+
+	// NOTE: Sidebar is the only state-dependent inert zone (FR-046).
+	if (z == Zone::Sidebar && state == MenuState::Searching)
+		return false;
+
+	return true;
+}
+
+Zone next_zone(VisibilityMask mask,
+               MenuState     state,
+               Zone          current,
+               Direction     direction)
+{
+	const std::size_t N = CANONICAL_CYCLE.size();
+
+	// Count active zones first; if there are none the contract returns
+	// `current` unchanged (FR-030 guarantees Search and Results are
+	// active, so this branch is unreachable in practice).
+	std::size_t active_count = 0;
+	for (Zone z : CANONICAL_CYCLE)
+	{
+		if (zone_active(z, mask, state))
+			++active_count;
+	}
+	if (active_count == 0)
+		return current;
+
+	// Locate the current zone's canonical index. The algorithm walks
+	// CANONICAL_CYCLE from that anchor and returns the first active
+	// zone in the requested direction, wrapping at the ends. When
+	// `current` is itself inert (e.g. the user just typed and Sidebar
+	// went inert mid-cycle) the anchor remains its canonical position,
+	// so the next active zone after Sidebar in Forward direction is
+	// Mode — matching contracts/focus-router.md row `current_is_inert_zone`.
+	std::size_t anchor = 0;
+	for (std::size_t k = 0; k < N; ++k)
+	{
+		if (CANONICAL_CYCLE[k] == current)
+		{
+			anchor = k;
+			break;
+		}
+	}
+
+	const int step = (direction == Direction::Forward) ? 1 : -1;
+	for (std::size_t i = 1; i <= N; ++i)
+	{
+		const std::size_t idx = (anchor + i * step + N * N) % N;
+		const Zone candidate = CANONICAL_CYCLE[idx];
+		if (zone_active(candidate, mask, state))
+			return candidate;
+	}
+
+	return current;
+}
+
+EscState classify_esc_state(bool context_menu_open,
+                            bool resize_in_progress,
+                            bool query_non_empty)
+{
+	if (context_menu_open)
+		return EscState::ContextMenuOpen;
+	if (resize_in_progress)
+		return EscState::ResizeInProgress;
+	if (query_non_empty)
+		return EscState::QueryNonEmpty;
+	return EscState::MenuOpen;
+}
+
+EscAction esc_action(EscState state)
+{
+	switch (state)
+	{
+	case EscState::ContextMenuOpen:  return EscAction::CloseContextMenu;
+	case EscState::ResizeInProgress: return EscAction::CancelResize;
+	case EscState::QueryNonEmpty:    return EscAction::ClearQuery;
+	case EscState::MenuOpen:         return EscAction::CloseMenu;
+	}
+	// Unreachable; total over the enum.
+	return EscAction::CloseMenu;
+}
+
+namespace
+{
+
+/* is_bare_modifier_keyval:
+ * @keyval: the GDK keysym from a key-press event.
+ *
+ * Lift-and-test for the bare-modifier set listed in
+ * contracts/key-routing.md §"Bare modifiers".
+ *
+ * Returns: true iff @keyval names a modifier-only key.
+ */
+bool is_bare_modifier_keyval(guint keyval)
+{
+	switch (keyval)
+	{
+	case GDK_KEY_Shift_L:
+	case GDK_KEY_Shift_R:
+	case GDK_KEY_Control_L:
+	case GDK_KEY_Control_R:
+	case GDK_KEY_Alt_L:
+	case GDK_KEY_Alt_R:
+	case GDK_KEY_Super_L:
+	case GDK_KEY_Super_R:
+	case GDK_KEY_Hyper_L:
+	case GDK_KEY_Hyper_R:
+	case GDK_KEY_Meta_L:
+	case GDK_KEY_Meta_R:
+	case GDK_KEY_ISO_Level3_Shift:
+	case GDK_KEY_ISO_Level5_Shift:
+	case GDK_KEY_Caps_Lock:
+	case GDK_KEY_Num_Lock:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/* is_function_utility_keyval:
+ * @keyval: the GDK keysym from a key-press event.
+ *
+ * Tests against the FunctionUtility set from contracts/key-routing.md
+ * §"Function and utility keys". Tab/Backspace/Enter/Escape are NOT
+ * in this set — they are handled by dedicated branches upstream and
+ * must never reach the post-default catch-all.
+ *
+ * Returns: true iff @keyval is in the function/utility set.
+ */
+bool is_function_utility_keyval(guint keyval)
+{
+	if (keyval >= GDK_KEY_F1 && keyval <= GDK_KEY_F12)
+		return true;
+	switch (keyval)
+	{
+	case GDK_KEY_Insert:
+	case GDK_KEY_KP_Insert:
+	case GDK_KEY_Delete:
+	case GDK_KEY_KP_Delete:
+	case GDK_KEY_Print:
+	case GDK_KEY_Scroll_Lock:
+	case GDK_KEY_Pause:
+	case GDK_KEY_Menu:
+	case GDK_KEY_Home:
+	case GDK_KEY_KP_Home:
+	case GDK_KEY_End:
+	case GDK_KEY_KP_End:
+	case GDK_KEY_Page_Up:
+	case GDK_KEY_KP_Page_Up:
+	case GDK_KEY_Page_Down:
+	case GDK_KEY_KP_Page_Down:
+	case GDK_KEY_Up:
+	case GDK_KEY_KP_Up:
+	case GDK_KEY_Down:
+	case GDK_KEY_KP_Down:
+	case GDK_KEY_Left:
+	case GDK_KEY_KP_Left:
+	case GDK_KEY_Right:
+	case GDK_KEY_KP_Right:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace
+
+KeyClass classify_key(const GdkEventKey* event)
+{
+	if (!event)
+		return KeyClass::FunctionUtility;
+
+	// IME first: GTK reserves bit 25 of GdkModifierType to mark
+	// IM-consumed events. Anything carrying that bit MUST be left
+	// alone so the in-progress composition can complete.
+	if (event->state & GDK_MODIFIER_RESERVED_25_MASK)
+		return KeyClass::ImeComposition;
+
+	if (event->is_modifier || is_bare_modifier_keyval(event->keyval))
+		return KeyClass::ModifierOnly;
+
+	if (is_function_utility_keyval(event->keyval))
+		return KeyClass::FunctionUtility;
+
+	// Printable test: a key produces a character (gdk_keyval_to_unicode
+	// returns non-zero) AND neither Ctrl nor Alt is held. Shift alone
+	// is fine — it produces uppercase letters and shifted symbols.
+	const guint32 unichar = gdk_keyval_to_unicode(event->keyval);
+	if (unichar == 0)
+		return KeyClass::FunctionUtility;
+
+	// NOTE: control characters (Tab 0x09, Backspace 0x08, Return 0x0d,
+	// Escape 0x1b, etc.) all have non-zero gdk_keyval_to_unicode but
+	// must NOT be routed into the search entry as printable text:
+	// they each have dedicated dispatch paths (zone cycling on Tab,
+	// activation on Return, the Esc ladder, and an explicit Backspace
+	// branch for FR-013). Excluding them here keeps the post-default
+	// printable catch-all from accidentally inserting "\b", "\t",
+	// "\r", or "\x1b" into the query when focus is off the entry.
+	if (unichar < 0x20 || unichar == 0x7F)
+		return KeyClass::FunctionUtility;
+
+	if (event->state & (GDK_CONTROL_MASK | GDK_MOD1_MASK))
+		return KeyClass::FunctionUtility;
+
+	return KeyClass::Printable;
+}
+
+bool is_printable_for_search(const GdkEventKey* event)
+{
+	return classify_key(event) == KeyClass::Printable;
+}
+
+} // namespace Keyboard
+} // namespace WhiskerMenu

--- a/panel-plugin/core/window-keyboard.h
+++ b/panel-plugin/core/window-keyboard.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEOWMENU_CORE_WINDOW_KEYBOARD_H
+#define MEOWMENU_CORE_WINDOW_KEYBOARD_H
+
+#include <array>
+#include <cstdint>
+
+#include <gdk/gdk.h>
+
+namespace WhiskerMenu
+{
+namespace Keyboard
+{
+
+/* Logical focusable region of the menu. The cycle order used by Tab /
+ * Shift+Tab is the declared numeric order below; see CANONICAL_CYCLE. */
+enum class Zone : unsigned
+{
+	Search  = 0,
+	Results = 1,
+	Sidebar = 2,
+	Mode    = 3,
+	Profile = 4,
+};
+
+/* Reflects whether the user is currently typing a query. The sidebar is
+ * inert (skipped from the Tab cycle) while Searching. */
+enum class MenuState : unsigned
+{
+	Browsing,
+	Searching,
+};
+
+enum class Direction : unsigned
+{
+	Forward,
+	Backward,
+};
+
+/* Per-zone visibility mask folded from the existing m_layout_* flags
+ * and the preset's per-zone "hidden" positions. Search and Results
+ * are forced visible per FR-030. */
+struct VisibilityMask
+{
+	bool search  = true;
+	bool results = true;
+	bool sidebar = true;
+	bool mode    = true;
+	bool profile = true;
+};
+
+/* Canonical, locale-independent Tab cycle order (FR-030, FR-031). RTL
+ * does not reverse it; arrow keys handle visual direction separately
+ * (FR-120). */
+constexpr std::array<Zone, 5> CANONICAL_CYCLE = {
+	Zone::Search, Zone::Results, Zone::Sidebar, Zone::Mode, Zone::Profile,
+};
+
+/* zone_active:
+ * @z: the zone in question.
+ * @mask: the visibility mask folded from layout flags.
+ * @state: Browsing or Searching.
+ *
+ * True iff @z is both visible (per @mask) and not inert in the given
+ * @state. Sidebar is the only zone whose activity depends on @state
+ * (inert while Searching, per FR-046).
+ */
+bool zone_active(Zone z, VisibilityMask mask, MenuState state);
+
+/* next_zone:
+ * @mask: visibility mask folded from layout flags.
+ * @state: Browsing or Searching.
+ * @current: currently focused zone (may itself be inert/hidden — treated
+ *           as a virtual position before filtered[0] going Forward, or
+ *           after filtered[N-1] going Backward).
+ * @direction: Forward for Tab, Backward for Shift+Tab.
+ *
+ * Returns the next zone to receive focus, walking CANONICAL_CYCLE with
+ * the inactive zones filtered out and wrapping around at the ends.
+ * Falls back to @current if no zone is active (unreachable in practice
+ * because Search and Results are never hidden).
+ */
+Zone next_zone(VisibilityMask mask,
+               MenuState     state,
+               Zone          current,
+               Direction     direction);
+
+/* States the next Esc press operates on, highest priority first. */
+enum class EscState : unsigned
+{
+	ContextMenuOpen  = 0,
+	ResizeInProgress = 1,
+	QueryNonEmpty    = 2,
+	MenuOpen         = 3,
+};
+
+/* Single-step action selected by the Esc ladder. */
+enum class EscAction : unsigned
+{
+	CloseContextMenu,
+	CancelResize,
+	ClearQuery,
+	CloseMenu,
+};
+
+/* classify_esc_state:
+ * @context_menu_open: a launcher/places context menu currently has the
+ *                     grab.
+ * @resize_in_progress: Window is mid-resize (m_resizing).
+ * @query_non_empty: the search entry currently contains at least one
+ *                   character.
+ *
+ * Strict priority: ContextMenuOpen > ResizeInProgress > QueryNonEmpty
+ * > MenuOpen. The first true predicate, top-down, wins.
+ *
+ * Returns: the EscState that the ladder should dispatch on.
+ */
+EscState classify_esc_state(bool context_menu_open,
+                            bool resize_in_progress,
+                            bool query_non_empty);
+
+/* esc_action:
+ * @state: the classified Esc state.
+ *
+ * Pure mapping from EscState to EscAction. One Esc press, one action;
+ * subsequent presses operate on the resulting state.
+ *
+ * Returns: the action the caller must perform; the caller MUST return
+ * GDK_EVENT_STOP after invoking it.
+ */
+EscAction esc_action(EscState state);
+
+/* Classification used by the type-to-search post-default handler. */
+enum class KeyClass : unsigned
+{
+	ImeComposition,  // part of an active IME sequence; do not route
+	ModifierOnly,    // bare modifier press (Shift, Ctrl, ...)
+	FunctionUtility, // F1..F12, Insert, Delete, navigation keys, ...
+	Printable,       // candidate for routing into the search entry
+};
+
+/* classify_key:
+ * @event: the GdkEventKey* delivered to the post-default handler.
+ *
+ * Applies the rules from contracts/key-routing.md in order:
+ *   1. IM-composition bit (GDK_MODIFIER_RESERVED_25_MASK)
+ *   2. Bare-modifier set
+ *   3. Function / utility keyval set
+ *   4. Printable test (gdk_keyval_to_unicode != 0 and no Ctrl/Alt held)
+ *
+ * Total function over GdkEventKey*; every input maps to exactly one
+ * KeyClass. Space classifies as Printable (FR-010).
+ *
+ * Returns: the KeyClass of the event.
+ */
+KeyClass classify_key(const GdkEventKey* event);
+
+/* is_printable_for_search:
+ * @event: the GdkEventKey* delivered to the post-default handler.
+ *
+ * Convenience predicate: classify_key(event) == KeyClass::Printable.
+ *
+ * Returns: true iff the event should be routed to the search entry.
+ */
+bool is_printable_for_search(const GdkEventKey* event);
+
+/* Monotonic-clock guard absorbing key-repeat bursts on Enter against a
+ * single launchable (FR-022, SC-005). Shared between launcher and
+ * profile-bar activation sites. */
+struct ActivationDebounce
+{
+	gint64 last_at      = 0;
+	gint64 threshold_us = 250 * 1000;
+
+	/* accept:
+	 * @now: g_get_monotonic_time() at call site.
+	 *
+	 * Returns true and updates @last_at iff @now - @last_at >=
+	 * @threshold_us. Otherwise returns false without mutating state.
+	 */
+	bool accept(gint64 now)
+	{
+		if (now - last_at >= threshold_us)
+		{
+			last_at = now;
+			return true;
+		}
+		return false;
+	}
+};
+
+} // namespace Keyboard
+} // namespace WhiskerMenu
+
+#endif // MEOWMENU_CORE_WINDOW_KEYBOARD_H

--- a/panel-plugin/core/window-pages.cpp
+++ b/panel-plugin/core/window-pages.cpp
@@ -24,6 +24,7 @@
 #include "places/places-page.h"
 #include "search/search-page.h"
 #include "settings.h"
+#include "ui/launcher-view.h"
 
 #include <libxfce4ui/libxfce4ui.h>
 
@@ -182,6 +183,12 @@ void WhiskerMenu::Window::search()
 		// Places mode: stay on the places panel; filter the active section.
 		gtk_stack_set_visible_child_name(m_panels_stack, "places");
 		m_places->set_filter(text);
+		// FR-014: query empty → return focus to the search entry so the
+		// user is back in Browsing-style entry focus.
+		if (!text)
+		{
+			gtk_widget_grab_focus(GTK_WIDGET(m_search_entry));
+		}
 		return;
 	}
 
@@ -203,6 +210,27 @@ void WhiskerMenu::Window::search()
 
 	// Apply filter
 	m_search_results->set_filter(text);
+
+	if (text)
+	{
+		// FR-011: when the query produced at least one result, move
+		// keyboard focus to the first result so the user can press
+		// Enter to launch it or use arrows to navigate. Subsequent
+		// printable keystrokes are still routed back into the entry
+		// via the on_key_press_event_after catch-all (FR-012).
+		GtkTreeModel* model = m_search_results->get_view()->get_model();
+		GtkTreeIter iter;
+		if (model && gtk_tree_model_get_iter_first(model, &iter))
+		{
+			gtk_widget_grab_focus(m_search_results->get_view()->get_widget());
+		}
+	}
+	else
+	{
+		// FR-014: query became empty (Backspace-to-empty or Esc-clear);
+		// return focus to the entry so the user is back in Browsing.
+		gtk_widget_grab_focus(GTK_WIDGET(m_search_entry));
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/core/window-pages.cpp
+++ b/panel-plugin/core/window-pages.cpp
@@ -223,6 +223,7 @@ void WhiskerMenu::Window::search()
 		if (model && gtk_tree_model_get_iter_first(model, &iter))
 		{
 			gtk_widget_grab_focus(m_search_results->get_view()->get_widget());
+			m_search_results->select_first();
 		}
 	}
 	else

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -1386,6 +1386,7 @@ Keyboard::MenuState WhiskerMenu::Window::current_menu_state() const
 void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
 {
 	GtkWidget* target = nullptr;
+	Page* results_page = nullptr;
 
 	switch (zone)
 	{
@@ -1395,13 +1396,14 @@ void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
 
 	case Keyboard::Zone::Results:
 	{
-		// Prefer the currently active page's view; if it has no selection
-		// the natural focus-grab handler will leave the cursor on the
-		// first row (GtkTreeView/GtkIconView default).
+		// FR-032: on Tab entry, land on the currently selected item; if
+		// nothing is selected, select the first item so the user has a
+		// visible anchor (select_first() is called after the grab below).
 		Page* page = const_cast<Window*>(this)->get_active_page();
 		if (page)
 		{
 			target = page->get_view()->get_widget();
+			results_page = page;
 		}
 		break;
 	}
@@ -1441,6 +1443,18 @@ void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
 	if (target && gtk_widget_get_visible(target) && gtk_widget_get_sensitive(target))
 	{
 		gtk_widget_grab_focus(target);
+		if (results_page)
+		{
+			GtkTreePath* sel = results_page->get_view()->get_selected_path();
+			if (!sel)
+			{
+				results_page->select_first();
+			}
+			else
+			{
+				gtk_tree_path_free(sel);
+			}
+		}
 	}
 }
 

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -43,7 +43,10 @@
 #include <gtk-layer-shell.h>
 #endif
 
+#include <algorithm>
 #include <ctime>
+#include <iterator>
+#include <vector>
 
 using namespace WhiskerMenu;
 
@@ -296,15 +299,110 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 	// Create the profile picture and username label
 	m_profile = new Profile(m_settings, this);
 
-	// Create action buttons
+	// Create action buttons. FR-022 / SC-005: a 250 ms monotonic-clock
+	// debounce absorbs held-Enter key-repeat bursts so a single press
+	// (or burst) launches exactly once. The state is process-global
+	// across the nine session buttons because the user can only target
+	// one button per keypress, and a stuck key must not fan out across
+	// adjacent buttons.
+	static Keyboard::ActivationDebounce s_command_debounce;
 	for (int i = 0; i < 9; ++i)
 	{
 		m_commands_button[i] = m_settings->command[i]->get_button();
+		// FR-040: session buttons participate in the keyboard focus chain.
+		gtk_widget_set_can_focus(m_commands_button[i], TRUE);
+		gtk_style_context_add_class(gtk_widget_get_style_context(m_commands_button[i]),
+				"meow-focus-ring");
 		m_command_slots[i] = connect(m_commands_button[i], "clicked",
 			[this](GtkButton*)
 			{
+				if (!s_command_debounce.accept(g_get_monotonic_time()))
+				{
+					return;
+				}
 				hide();
 			});
+	}
+
+	// FR-040: ←/→ move focus between visible session buttons in physical
+	// box order with NO wrap. ↑/↓ are no-ops within the Profile bar so
+	// they do not accidentally jump to other zones (Tab is the cross-zone
+	// motion). The avatar/username are kept non-focusable below.
+	auto profile_arrow_handler = [this](GtkWidget* widget, GdkEvent* ev) -> gboolean
+	{
+		GdkEventKey* key = reinterpret_cast<GdkEventKey*>(ev);
+		const bool left  = (key->keyval == GDK_KEY_Left
+				|| key->keyval == GDK_KEY_KP_Left);
+		const bool right = (key->keyval == GDK_KEY_Right
+				|| key->keyval == GDK_KEY_KP_Right);
+		const bool up    = (key->keyval == GDK_KEY_Up
+				|| key->keyval == GDK_KEY_KP_Up);
+		const bool down  = (key->keyval == GDK_KEY_Down
+				|| key->keyval == GDK_KEY_KP_Down);
+		if (up || down)
+		{
+			return GDK_EVENT_STOP; // explicit no-op within the bar
+		}
+		if (!left && !right)
+		{
+			return GDK_EVENT_PROPAGATE;
+		}
+
+		// Walk the focusable session buttons in their CURRENT physical
+		// box order. m_commands_box may reorder children for RTL or for
+		// the alternate-commands layout (see update_layout()), so we
+		// must read the live order rather than the m_commands_button
+		// declaration order.
+		GList* kids = gtk_container_get_children(GTK_CONTAINER(m_commands_box));
+		std::vector<GtkWidget*> ordered;
+		for (GList* li = kids; li; li = li->next)
+		{
+			GtkWidget* w = GTK_WIDGET(li->data);
+			if (!GTK_IS_BUTTON(w))
+				continue;
+			if (!gtk_widget_get_visible(w) || !gtk_widget_get_sensitive(w))
+				continue;
+			ordered.push_back(w);
+		}
+		g_list_free(kids);
+		if (ordered.empty())
+			return GDK_EVENT_STOP;
+
+		auto it = std::find(ordered.begin(), ordered.end(), widget);
+		if (it == ordered.end())
+			return GDK_EVENT_PROPAGATE;
+
+		// FR-120: in RTL the visual left/right are swapped relative to
+		// physical box order. Use the widget's default direction to
+		// pick the move sign rather than assuming LTR.
+		const bool ltr = (gtk_widget_get_default_direction()
+				!= GTK_TEXT_DIR_RTL);
+		const bool move_next = (ltr ? right : left);
+		const bool move_prev = (ltr ? left  : right);
+
+		if (move_next && std::next(it) != ordered.end())
+		{
+			gtk_widget_grab_focus(*std::next(it));
+		}
+		else if (move_prev && it != ordered.begin())
+		{
+			gtk_widget_grab_focus(*std::prev(it));
+		}
+		// At either end: explicit no-op (FR-040 "NO wrap").
+		return GDK_EVENT_STOP;
+	};
+	for (int i = 0; i < 9; ++i)
+	{
+		connect(m_commands_button[i], "key-press-event", profile_arrow_handler);
+	}
+
+	// The avatar event-box and username label are decorative only; keep
+	// them out of the focus chain so Tab into the Profile bar lands on
+	// the first visible session button (data-model "Entry widget mapping").
+	if (m_profile)
+	{
+		gtk_widget_set_can_focus(m_profile->get_picture(), FALSE);
+		gtk_widget_set_can_focus(m_profile->get_username(), FALSE);
 	}
 
 	// Create search entry
@@ -427,6 +525,17 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 			"places-mode-selector");
 	m_mode_btn_apps = GTK_TOGGLE_BUTTON(gtk_toggle_button_new_with_label(_("Apps")));
 	m_mode_btn_places = GTK_TOGGLE_BUTTON(gtk_toggle_button_new_with_label(_("Places")));
+	// FR-090: no Alt-mnemonic activation on the mode toggles — the labels
+	// "Apps"/"Places" must render verbatim, not as "_Apps"/"_Places".
+	gtk_button_set_use_underline(GTK_BUTTON(m_mode_btn_apps),   FALSE);
+	gtk_button_set_use_underline(GTK_BUTTON(m_mode_btn_places), FALSE);
+	// FR-002 / SC-007: shared focus-indicator class. The rule lives in
+	// the CSS provider built by update_background_css() so themes can
+	// override the ring colour/thickness by re-styling .meow-focus-ring.
+	gtk_style_context_add_class(gtk_widget_get_style_context(GTK_WIDGET(m_mode_btn_apps)),
+			"meow-focus-ring");
+	gtk_style_context_add_class(gtk_widget_get_style_context(GTK_WIDGET(m_mode_btn_places)),
+			"meow-focus-ring");
 	gtk_toggle_button_set_active(m_mode_btn_apps, true);
 	gtk_box_pack_start(m_mode_selector_box, GTK_WIDGET(m_mode_btn_apps), true, true, 0);
 	gtk_box_pack_start(m_mode_selector_box, GTK_WIDGET(m_mode_btn_places), true, true, 0);
@@ -449,6 +558,35 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 			else if (!gtk_toggle_button_get_active(m_mode_btn_apps))
 				gtk_toggle_button_set_active(b, true);
 		});
+
+	// FR-041 / FR-081: any arrow key on a mode toggle flips to the
+	// opposite toggle. Space is NOT bound (clarification Q1) — it falls
+	// through and is captured by the printable-key catch-all so it
+	// extends the query, matching FR-080. Key repeat is absorbed by
+	// m_mode_switch_in_progress inside switch_mode().
+	auto mode_arrow_handler = [this](GtkWidget*, GdkEvent* ev) -> gboolean
+	{
+		GdkEventKey* key = reinterpret_cast<GdkEventKey*>(ev);
+		switch (key->keyval)
+		{
+		case GDK_KEY_Left:  case GDK_KEY_KP_Left:
+		case GDK_KEY_Right: case GDK_KEY_KP_Right:
+		case GDK_KEY_Up:    case GDK_KEY_KP_Up:
+		case GDK_KEY_Down:  case GDK_KEY_KP_Down:
+			break;
+		default:
+			return GDK_EVENT_PROPAGATE;
+		}
+		const bool currently_places
+				= gtk_toggle_button_get_active(m_mode_btn_places);
+		GtkToggleButton* target = currently_places
+				? m_mode_btn_apps : m_mode_btn_places;
+		gtk_toggle_button_set_active(target, true);
+		gtk_widget_grab_focus(GTK_WIDGET(target));
+		return GDK_EVENT_STOP;
+	};
+	connect(m_mode_btn_apps,   "key-press-event", mode_arrow_handler);
+	connect(m_mode_btn_places, "key-press-event", mode_arrow_handler);
 
 	// Create search results
 	m_search_results = new SearchPage(m_settings, this);
@@ -586,6 +724,24 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 	gtk_scrolled_window_set_shadow_type(m_sidebar, GTK_SHADOW_NONE);
 	gtk_scrolled_window_set_policy(m_sidebar, GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 	gtk_container_add(GTK_CONTAINER(m_sidebar), GTK_WIDGET(m_category_buttons));
+
+	// FR-100: keep the focused category in view as Tab/arrow keys move
+	// through the sidebar. GtkScrolledWindow wraps m_category_buttons in
+	// a viewport on gtk_container_add; binding the viewport's
+	// adjustments to the box's focus chain makes the viewport scroll
+	// automatically on focus-grab. NOTE: needs both axes because the
+	// sidebar can be vertical or horizontal depending on preset
+	// (sidebar_position: left|right|top|bottom).
+	{
+		GtkWidget* viewport = gtk_bin_get_child(GTK_BIN(m_sidebar));
+		if (GTK_IS_VIEWPORT(viewport))
+		{
+			gtk_container_set_focus_vadjustment(GTK_CONTAINER(m_category_buttons),
+					gtk_scrolled_window_get_vadjustment(m_sidebar));
+			gtk_container_set_focus_hadjustment(GTK_CONTAINER(m_category_buttons),
+					gtk_scrolled_window_get_hadjustment(m_sidebar));
+		}
+	}
 
 	// Handle default page
 	reset_default_button();
@@ -1181,6 +1337,156 @@ void WhiskerMenu::Window::unset_items()
 
 //-----------------------------------------------------------------------------
 
+Keyboard::VisibilityMask WhiskerMenu::Window::current_visibility_mask() const
+{
+	// FR-030: Search and Results are never hidden. Optional zones follow
+	// the preset's per-zone "hidden" position string and the legacy
+	// visibility flags. Mode is the Apps/Places selector and is gated on
+	// places_enabled; Profile is the session-button row and is gated on
+	// commands_position != "hidden" with at least one visible command.
+	Keyboard::VisibilityMask mask;
+	mask.search  = true;
+	mask.results = true;
+
+	const char* sidebar_pos  = m_settings->sidebar_position;
+	const char* commands_pos = m_settings->commands_position;
+
+	mask.sidebar = (g_strcmp0(sidebar_pos, "hidden") != 0);
+	mask.mode    = m_settings->places_enabled;
+
+	bool any_command_visible = false;
+	if (g_strcmp0(commands_pos, "hidden") != 0)
+	{
+		for (int i = 0; i < 9; ++i)
+		{
+			if (m_commands_button[i] && gtk_widget_get_visible(m_commands_button[i]))
+			{
+				any_command_visible = true;
+				break;
+			}
+		}
+	}
+	mask.profile = any_command_visible;
+
+	return mask;
+}
+
+//-----------------------------------------------------------------------------
+
+Keyboard::MenuState WhiskerMenu::Window::current_menu_state() const
+{
+	const gchar* text = gtk_entry_get_text(m_search_entry);
+	return xfce_str_is_empty(text)
+			? Keyboard::MenuState::Browsing
+			: Keyboard::MenuState::Searching;
+}
+
+//-----------------------------------------------------------------------------
+
+void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
+{
+	GtkWidget* target = nullptr;
+
+	switch (zone)
+	{
+	case Keyboard::Zone::Search:
+		target = GTK_WIDGET(m_search_entry);
+		break;
+
+	case Keyboard::Zone::Results:
+	{
+		// Prefer the currently active page's view; if it has no selection
+		// the natural focus-grab handler will leave the cursor on the
+		// first row (GtkTreeView/GtkIconView default).
+		Page* page = const_cast<Window*>(this)->get_active_page();
+		if (page)
+		{
+			target = page->get_view()->get_widget();
+		}
+		break;
+	}
+
+	case Keyboard::Zone::Sidebar:
+		target = const_cast<Window*>(this)->get_active_category_button();
+		break;
+
+	case Keyboard::Zone::Mode:
+		// Focus the active mode toggle so the arrow-toggle handler in
+		// window-pages.cpp can flip from there (FR-041, FR-081).
+		if (m_mode_btn_places && gtk_toggle_button_get_active(m_mode_btn_places))
+		{
+			target = GTK_WIDGET(m_mode_btn_places);
+		}
+		else if (m_mode_btn_apps)
+		{
+			target = GTK_WIDGET(m_mode_btn_apps);
+		}
+		break;
+
+	case Keyboard::Zone::Profile:
+		// First visible+focusable command button in physical box order.
+		for (int i = 0; i < 9; ++i)
+		{
+			if (m_commands_button[i]
+					&& gtk_widget_get_visible(m_commands_button[i])
+					&& gtk_widget_get_can_focus(m_commands_button[i]))
+			{
+				target = m_commands_button[i];
+				break;
+			}
+		}
+		break;
+	}
+
+	if (target && gtk_widget_get_visible(target) && gtk_widget_get_sensitive(target))
+	{
+		gtk_widget_grab_focus(target);
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+Keyboard::Zone WhiskerMenu::Window::current_zone() const
+{
+	GtkWidget* focused = gtk_window_get_focus(m_window);
+	if (!focused)
+	{
+		return Keyboard::Zone::Search;
+	}
+
+	// Walk ancestors; the first recognised container wins. Order matters
+	// here — the search entry sits inside m_search_box which is a child
+	// of m_vbox, so test the entry directly before any box ancestor.
+	if (focused == GTK_WIDGET(m_search_entry))
+	{
+		return Keyboard::Zone::Search;
+	}
+
+	GtkWidget* mode_box  = m_mode_selector_box  ? GTK_WIDGET(m_mode_selector_box)  : nullptr;
+	GtkWidget* sidebar   = m_sidebar            ? GTK_WIDGET(m_sidebar)            : nullptr;
+	GtkWidget* cats_box  = m_categories_box     ? GTK_WIDGET(m_categories_box)     : nullptr;
+	GtkWidget* cmds_box  = m_commands_box       ? GTK_WIDGET(m_commands_box)       : nullptr;
+	GtkWidget* panels    = m_panels_stack       ? GTK_WIDGET(m_panels_stack)       : nullptr;
+
+	for (GtkWidget* w = focused; w; w = gtk_widget_get_parent(w))
+	{
+		if (mode_box && w == mode_box)
+			return Keyboard::Zone::Mode;
+		if (cmds_box && w == cmds_box)
+			return Keyboard::Zone::Profile;
+		if (sidebar && w == sidebar)
+			return Keyboard::Zone::Sidebar;
+		if (cats_box && w == cats_box)
+			return Keyboard::Zone::Sidebar;
+		if (panels && w == panels)
+			return Keyboard::Zone::Results;
+	}
+
+	return Keyboard::Zone::Search;
+}
+
+//-----------------------------------------------------------------------------
+
 gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey* key_event)
 {
 	// Type-to-search catch-all (FR-010, FR-012, FR-013, FR-015). This
@@ -1208,27 +1514,95 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		}
 	}
 
+	// Tab / Shift+Tab → canonical zone cycling (FR-030, FR-031, FR-032).
+	// Intercepted before GTK's default focus-chain so we can skip inert
+	// zones (Sidebar while Searching) and follow the canonical order
+	// regardless of layout-mode reorderings of the underlying box tree.
+	if (key_event->keyval == GDK_KEY_Tab
+			|| key_event->keyval == GDK_KEY_ISO_Left_Tab
+			|| key_event->keyval == GDK_KEY_KP_Tab)
+	{
+		const Keyboard::Direction dir =
+				((key_event->state & GDK_SHIFT_MASK)
+				 || key_event->keyval == GDK_KEY_ISO_Left_Tab)
+					? Keyboard::Direction::Backward
+					: Keyboard::Direction::Forward;
+		const Keyboard::Zone here = current_zone();
+		const Keyboard::Zone next = Keyboard::next_zone(
+				current_visibility_mask(),
+				current_menu_state(),
+				here,
+				dir);
+		if (next != here)
+		{
+			grab_focus_in_zone(next);
+		}
+		return GDK_EVENT_STOP;
+	}
+
 	if (key_event->keyval == GDK_KEY_Escape)
 	{
-		// Cancel resize
-		if (m_resizing)
+		// Esc ladder (FR-060, FR-061). Strict priority:
+		//   ContextMenuOpen > ResizeInProgress > QueryNonEmpty > MenuOpen.
+		// Each press peels one layer; Backspace/Delete MUST NOT close the
+		// menu (the explicit BackSpace branch above only redirects to the
+		// entry; the Esc ladder is the sole keyboard close path).
+		GtkWidget* esc_focused = gtk_window_get_focus(m_window);
+		bool context_menu_open = false;
+		for (GtkWidget* w = esc_focused; w; w = gtk_widget_get_parent(w))
 		{
+			if (GTK_IS_MENU(w))
+			{
+				context_menu_open = true;
+				break;
+			}
+		}
+		const bool query_non_empty
+				= !xfce_str_is_empty(gtk_entry_get_text(m_search_entry));
+
+		const Keyboard::EscState st = Keyboard::classify_esc_state(
+				context_menu_open, m_resizing, query_non_empty);
+		switch (Keyboard::esc_action(st))
+		{
+		case Keyboard::EscAction::CloseContextMenu:
+			// Forward the Esc into the active menu shell so it closes
+			// just that layer and returns focus to the originating
+			// launcher (FR-051).
+			if (esc_focused)
+			{
+				for (GtkWidget* w = esc_focused; w; w = gtk_widget_get_parent(w))
+				{
+					if (GTK_IS_MENU(w))
+					{
+						gtk_menu_shell_cancel(GTK_MENU_SHELL(w));
+						break;
+					}
+				}
+			}
+			break;
+
+		case Keyboard::EscAction::CancelResize:
 			for (Resizer* resizer : m_resize)
 			{
 				resizer->cancel();
 			}
 			set_size(m_settings->menu_width, m_settings->menu_height);
 			resize_end();
-		}
-		// Hide if escape is pressed and there is no text in search entry
-		else if (xfce_str_is_empty(gtk_entry_get_text(m_search_entry)))
-		{
-			hide();
-		}
-		// Clear search entry of text if escape is pressed
-		else
-		{
+			break;
+
+		case Keyboard::EscAction::ClearQuery:
 			gtk_entry_set_text(m_search_entry, "");
+			// FR-014 follow-up: focus returns to the entry so the user is
+			// back in Browsing. Window::search() also grabs focus to the
+			// entry when the text becomes empty, but make it explicit
+			// here so the ladder behaves the same regardless of where
+			// focus sat at Esc time.
+			gtk_widget_grab_focus(GTK_WIDGET(m_search_entry));
+			break;
+
+		case Keyboard::EscAction::CloseMenu:
+			hide();
+			break;
 		}
 		return GDK_EVENT_STOP;
 	}
@@ -1237,16 +1611,60 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 	GtkWidget* view = page->get_view()->get_widget();
 	GtkWidget* search = GTK_WIDGET(m_search_entry);
 
+	// FR-043 / FR-046: sidebar exit arrow → focus the results view. The
+	// "outward" arrow depends on sidebar side (left/right/top/bottom),
+	// which is encoded by m_layout_categories_horizontal,
+	// m_layout_categories_alternate and m_layout_ltr. Mirror is applied
+	// via gtk_widget_get_default_direction() so RTL behaves correctly.
+	// In Searching state the sidebar is inert and the exit arrow is a
+	// no-op (FR-046).
+	if (current_zone() == Keyboard::Zone::Sidebar
+			&& current_menu_state() == Keyboard::MenuState::Browsing)
+	{
+		guint outward = 0;
+		if (m_layout_categories_horizontal)
+		{
+			// alternate=true → sidebar at bottom → outward is Up
+			outward = m_layout_categories_alternate
+					? GDK_KEY_Up : GDK_KEY_Down;
+		}
+		else
+		{
+			// sidebar_on_left when (m_layout_ltr == m_layout_categories_alternate)
+			const bool sidebar_on_left
+					= (m_layout_ltr == m_layout_categories_alternate);
+			outward = sidebar_on_left ? GDK_KEY_Right : GDK_KEY_Left;
+		}
+		const guint kv = key_event->keyval;
+		const bool match_outward
+				= (kv == outward)
+				|| (outward == GDK_KEY_Up    && kv == GDK_KEY_KP_Up)
+				|| (outward == GDK_KEY_Down  && kv == GDK_KEY_KP_Down)
+				|| (outward == GDK_KEY_Left  && kv == GDK_KEY_KP_Left)
+				|| (outward == GDK_KEY_Right && kv == GDK_KEY_KP_Right);
+		if (match_outward)
+		{
+			gtk_widget_grab_focus(view);
+			return GDK_EVENT_STOP;
+		}
+	}
+
 	switch (key_event->keyval)
 	{
 	case GDK_KEY_Left:
 	case GDK_KEY_KP_Left:
 	case GDK_KEY_Right:
 	case GDK_KEY_KP_Right:
-		// Allow keyboard navigation out of treeview
+		// Allow keyboard navigation out of treeview. NOTE: in Searching
+		// state the sidebar is inert (FR-046); the exit arrow MUST be a
+		// no-op so the user can keep refining the query with arrow keys
+		// inside the result list.
 		if (GTK_IS_TREE_VIEW(view) && ((widget == view) || (gtk_window_get_focus(m_window) == view)))
 		{
-			gtk_widget_grab_focus(get_active_category_button());
+			if (current_menu_state() == Keyboard::MenuState::Browsing)
+			{
+				gtk_widget_grab_focus(get_active_category_button());
+			}
 		}
 		// Allow keyboard navigation out of search into iconview
 		else if (GTK_IS_ICON_VIEW(view) && ((widget == search) || (gtk_window_get_focus(m_window) == search)))
@@ -1293,7 +1711,10 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		break;
 	}
 
-	// Pass PageUp and PageDown keys to current view
+	// Pass PageUp and PageDown keys to current view. FR-047: when focus
+	// was on the search entry and no row was selected yet, also select
+	// the first row so the user sees a visual anchor for the subsequent
+	// Page motion.
 	case GDK_KEY_Page_Up:
 	case GDK_KEY_KP_Page_Up:
 	case GDK_KEY_Page_Down:
@@ -1301,6 +1722,15 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		if ((widget == search) || (gtk_window_get_focus(m_window) == search))
 		{
 			gtk_widget_grab_focus(view);
+			GtkTreePath* selected = page->get_view()->get_selected_path();
+			if (!selected)
+			{
+				page->select_first();
+			}
+			else
+			{
+				gtk_tree_path_free(selected);
+			}
 		}
 		break;
 
@@ -1400,7 +1830,19 @@ void WhiskerMenu::Window::update_background_css()
 		".meowmenu .category-button *,"
 		".meowmenu .category-button image,"
 		".meowmenu .category-button label"
-		"{ opacity: 1; }",
+		"{ opacity: 1; }"
+		// FR-002 / SC-007: keyboard focus indicator. The 1 px inset
+		// outline sits inside the widget border (outline-offset: -1px)
+		// so the widget does not change size on focus and the
+		// surrounding layout does not shift. :focus-visible restricts
+		// the ring to keyboard focus, never mouse click. Themes can
+		// override .meow-focus-ring to recolour or thicken the ring.
+		".meowmenu .meow-focus-ring:focus-visible,"
+		".meowmenu .category-button:focus-visible,"
+		".meowmenu entry:focus-visible,"
+		".meowmenu treeview:focus-visible,"
+		".meowmenu iconview:focus-visible"
+		"{ outline: 1px solid @theme_selected_bg_color; outline-offset: -1px; }",
 		red, green, blue, cats_alpha,
 		red, green, blue, apps_alpha);
 

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -1399,11 +1399,20 @@ void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
 		// FR-032: on Tab entry, land on the currently selected item; if
 		// nothing is selected, select the first item so the user has a
 		// visible anchor (select_first() is called after the grab below).
-		Page* page = const_cast<Window*>(this)->get_active_page();
-		if (page)
+		// NOTE: in Places mode get_active_page() returns the hidden applications
+		// page; target m_places directly so the grab lands on the visible widget.
+		if (m_places_active)
 		{
-			target = page->get_view()->get_widget();
-			results_page = page;
+			target = m_places->get_view()->get_widget();
+		}
+		else
+		{
+			Page* page = const_cast<Window*>(this)->get_active_page();
+			if (page)
+			{
+				target = page->get_view()->get_widget();
+				results_page = page;
+			}
 		}
 		break;
 	}
@@ -1622,7 +1631,11 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 	}
 
 	Page* page = get_active_page();
-	GtkWidget* view = page->get_view()->get_widget();
+	// NOTE: in Places mode get_active_page() returns the hidden applications
+	// page; use m_places directly so focus and selection target the visible view.
+	GtkWidget* view = m_places_active
+		? m_places->get_view()->get_widget()
+		: page->get_view()->get_widget();
 	GtkWidget* search = GTK_WIDGET(m_search_entry);
 
 	// FR-043 / FR-046: sidebar exit arrow → focus the results view. The
@@ -1701,10 +1714,12 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 	case GDK_KEY_KP_Down:
 	{
 		// Determine if there is a selected item
-		bool reset = page != m_search_results;
+		LauncherView* results_view = m_places_active
+			? m_places->get_view() : page->get_view();
+		bool reset = m_places_active ? true : (page != m_search_results);
 		if (reset)
 		{
-			GtkTreePath* path = page->get_view()->get_selected_path();
+			GtkTreePath* path = results_view->get_selected_path();
 			if (path)
 			{
 				reset = false;
@@ -1719,7 +1734,7 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		// Only select first item if there is no selected item
 		if ((gtk_window_get_focus(m_window) == view) && reset)
 		{
-			page->select_first();
+			m_places_active ? m_places->select_first() : page->select_first();
 			return GDK_EVENT_STOP;
 		}
 		break;
@@ -1736,10 +1751,12 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		if ((widget == search) || (gtk_window_get_focus(m_window) == search))
 		{
 			gtk_widget_grab_focus(view);
-			GtkTreePath* selected = page->get_view()->get_selected_path();
+			LauncherView* results_view = m_places_active
+				? m_places->get_view() : page->get_view();
+			GtkTreePath* selected = results_view->get_selected_path();
 			if (!selected)
 			{
-				page->select_first();
+				m_places_active ? m_places->select_first() : page->select_first();
 			}
 			else
 			{

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -34,6 +34,7 @@
 #include "settings.h"
 #include "ui/slot.h"
 #include "search/unified-bar.h"
+#include "window-keyboard.h"
 
 #include <libxfce4ui/libxfce4ui.h>
 #include <gdk/gdkkeysyms.h>
@@ -314,6 +315,21 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 		[this](GtkEditable*)
 		{
 			search();
+		});
+
+	// FR-021: Enter on the search entry activates the first match (or
+	// is a silent no-op when the current query has zero results — see
+	// clarification Q4). The debounce inside Page::launcher_activated
+	// covers held-Enter key-repeat (FR-022).
+	connect(m_search_entry, "activate",
+		[this](GtkEntry*)
+		{
+			const gchar* text = gtk_entry_get_text(m_search_entry);
+			if (xfce_str_is_empty(text))
+			{
+				return;
+			}
+			m_search_results->activate_first();
 		});
 
 	connect(m_search_entry, "populate-popup",
@@ -1167,6 +1183,31 @@ void WhiskerMenu::Window::unset_items()
 
 gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey* key_event)
 {
+	// Type-to-search catch-all (FR-010, FR-012, FR-013, FR-015). This
+	// runs BEFORE GTK's default key chain so that:
+	//   - Printable keys typed while focus is on the results view do
+	//     not reach the view's default Space-activates-row handler.
+	//   - Each character is delivered to the entry exactly once (the
+	//     post-default signal must not also re-route, otherwise every
+	//     keystroke would be inserted twice once Window::search()
+	//     moves focus to the view).
+	// Backspace gets a dedicated branch (FR-013): it must remove a
+	// character from the query regardless of which zone holds focus,
+	// but it is not classified Printable (control codepoint) and
+	// therefore cannot ride the generic printable redirect.
+	GtkWidget* entry = GTK_WIDGET(m_search_entry);
+	GtkWidget* focused = gtk_window_get_focus(m_window);
+	if (focused && focused != entry)
+	{
+		if (Keyboard::is_printable_for_search(key_event)
+				|| key_event->keyval == GDK_KEY_BackSpace)
+		{
+			gtk_entry_grab_focus_without_selecting(m_search_entry);
+			gtk_window_propagate_key_event(m_window, key_event);
+			return GDK_EVENT_STOP;
+		}
+	}
+
 	if (key_event->keyval == GDK_KEY_Escape)
 	{
 		// Cancel resize
@@ -1272,20 +1313,15 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 
 //-----------------------------------------------------------------------------
 
-gboolean WhiskerMenu::Window::on_key_press_event_after(GtkWidget* widget, GdkEventKey* key_event)
+gboolean WhiskerMenu::Window::on_key_press_event_after(GtkWidget* /*widget*/, GdkEventKey* /*key_event*/)
 {
-	// Pass unhandled key presses to search entry
-	GtkWidget* search_entry = GTK_WIDGET(m_search_entry);
-	if ((widget != search_entry) && (gtk_window_get_focus(m_window) != search_entry))
-	{
-		if (key_event->is_modifier)
-		{
-			return GDK_EVENT_PROPAGATE;
-		}
-		gtk_entry_grab_focus_without_selecting(m_search_entry);
-		gtk_window_propagate_key_event(m_window, key_event);
-		return GDK_EVENT_STOP;
-	}
+	// NOTE: type-to-search routing moved to the pre-default handler
+	// above so it can pre-empt GtkTreeView/GtkIconView's "Space
+	// activates the selected row" default binding (FR-012). Keeping
+	// a duplicate redirect here would cause every keystroke to be
+	// inserted twice once Window::search() moves focus to the view
+	// per FR-011. The post-default slot remains attached as a hook
+	// point for future expansion; today it is a no-op.
 	return GDK_EVENT_PROPAGATE;
 }
 

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -22,6 +22,8 @@
 
 #include <gtk/gtk.h>
 
+#include "window-keyboard.h"
+
 namespace WhiskerMenu
 {
 
@@ -101,6 +103,43 @@ private:
 	GtkWidget* get_active_category_button();
 	gboolean on_key_press_event(GtkWidget* widget, GdkEventKey* key_event);
 	gboolean on_key_press_event_after(GtkWidget* widget, GdkEventKey* key_event);
+
+	/* current_visibility_mask:
+	 *
+	 * Folds the live layout flags and per-zone "hidden" positions into a
+	 * Keyboard::VisibilityMask. Search and Results are forced visible
+	 * (FR-030); the Sidebar, Mode selector, and Profile bar follow the
+	 * preset's per-zone position string and visibility flags.
+	 */
+	Keyboard::VisibilityMask current_visibility_mask() const;
+
+	/* current_menu_state:
+	 *
+	 * Returns Searching iff the search entry holds at least one
+	 * character, Browsing otherwise. Used by the focus router to skip
+	 * the inert sidebar while typing (FR-046).
+	 */
+	Keyboard::MenuState current_menu_state() const;
+
+	/* grab_focus_in_zone:
+	 * @zone: target zone for Tab/Shift+Tab.
+	 *
+	 * Maps a logical Zone to the concrete widget that should receive
+	 * focus on entry per data-model §"Entry widget mapping" and calls
+	 * gtk_widget_grab_focus on it. If the natural entry widget is not
+	 * realized/visible the call is a no-op and the previously focused
+	 * widget keeps focus.
+	 */
+	void grab_focus_in_zone(Keyboard::Zone zone);
+
+	/* current_zone:
+	 *
+	 * Identifies which logical Zone currently holds the focus, by
+	 * walking up the focused widget's ancestor chain. Falls back to
+	 * Zone::Search when nothing matches (e.g. focus is on the menu
+	 * window itself just after open).
+	 */
+	Keyboard::Zone current_zone() const;
 	gboolean on_map_event();
 	void on_state_flags_changed(GtkWidget* widget);
 	void on_screen_changed(GtkWidget* widget);

--- a/panel-plugin/launcher/category-button.cpp
+++ b/panel-plugin/launcher/category-button.cpp
@@ -21,8 +21,55 @@
 #include "ui/slot.h"
 
 #include <libxfce4panel/libxfce4panel.h>
+#include <gdk/gdkkeysyms.h>
 
 using namespace WhiskerMenu;
+
+namespace
+{
+
+/* focusable_radio_siblings:
+ * @parent: the GtkBox holding a GtkRadioButton group.
+ *
+ * Collects the visible, sensitive radio-button children in physical
+ * box order. Non-radio children (separators, the mode selector box)
+ * are skipped so wrap-around stays inside the category group.
+ *
+ * Returns: heap-allocated GList* of GtkWidget*; the caller frees it
+ * with g_list_free (do NOT free the nodes themselves).
+ */
+GList* focusable_radio_siblings(GtkContainer* parent)
+{
+	GList* out = nullptr;
+	GList* children = gtk_container_get_children(parent);
+	for (GList* li = children; li; li = li->next)
+	{
+		GtkWidget* w = GTK_WIDGET(li->data);
+		if (!GTK_IS_RADIO_BUTTON(w))
+			continue;
+		if (!gtk_widget_get_visible(w) || !gtk_widget_get_sensitive(w))
+			continue;
+		out = g_list_append(out, w);
+	}
+	g_list_free(children);
+	return out;
+}
+
+/* sidebar_is_vertical:
+ * @parent: the GtkBox holding the category buttons.
+ *
+ * Returns: true iff the parent box is oriented vertically (sidebar at
+ * left or right); false when it is horizontal (sidebar at top/bottom).
+ */
+bool sidebar_is_vertical(GtkContainer* parent)
+{
+	if (!GTK_IS_ORIENTABLE(parent))
+		return true;
+	return gtk_orientable_get_orientation(GTK_ORIENTABLE(parent))
+			== GTK_ORIENTATION_VERTICAL;
+}
+
+} // namespace
 
 //-----------------------------------------------------------------------------
 
@@ -66,6 +113,76 @@ CategoryButton::CategoryButton(Settings* settings, GIcon* icon, const gchar* tex
 			{
 				gtk_toggle_button_set_active(button, true);
 				gtk_widget_grab_focus(widget);
+			}
+			return GDK_EVENT_PROPAGATE;
+		});
+
+	// FR-042: ↑/↓ (or ←/→ in horizontal sidebar layouts) wrap at the
+	// ends of the category group; Home/End jump to first/last. The
+	// exit-to-results arrow (perpendicular to the sidebar axis) is left
+	// to the window-level handler in Window::on_key_press_event which
+	// checks FR-046 (no-op while Searching) and the LTR/RTL mirror
+	// (FR-120).
+	connect(m_button, "key-press-event",
+		[](GtkWidget* widget, GdkEvent* ev) -> gboolean
+		{
+			GdkEventKey* key = reinterpret_cast<GdkEventKey*>(ev);
+			GtkWidget* parent = gtk_widget_get_parent(widget);
+			if (!parent)
+				return GDK_EVENT_PROPAGATE;
+
+			GList* siblings = focusable_radio_siblings(GTK_CONTAINER(parent));
+			if (!siblings)
+				return GDK_EVENT_PROPAGATE;
+
+			const bool vertical = sidebar_is_vertical(GTK_CONTAINER(parent));
+			const guint kv = key->keyval;
+
+			GList* self_node = g_list_find(siblings, widget);
+			const bool at_first = (self_node == siblings);
+			const bool at_last  = (self_node && self_node->next == nullptr);
+
+			GtkWidget* target = nullptr;
+
+			if (kv == GDK_KEY_Home || kv == GDK_KEY_KP_Home)
+			{
+				target = GTK_WIDGET(siblings->data);
+			}
+			else if (kv == GDK_KEY_End || kv == GDK_KEY_KP_End)
+			{
+				target = GTK_WIDGET(g_list_last(siblings)->data);
+			}
+			else if (vertical
+					&& (kv == GDK_KEY_Up || kv == GDK_KEY_KP_Up)
+					&& at_first)
+			{
+				target = GTK_WIDGET(g_list_last(siblings)->data);
+			}
+			else if (vertical
+					&& (kv == GDK_KEY_Down || kv == GDK_KEY_KP_Down)
+					&& at_last)
+			{
+				target = GTK_WIDGET(siblings->data);
+			}
+			else if (!vertical
+					&& (kv == GDK_KEY_Left || kv == GDK_KEY_KP_Left)
+					&& at_first)
+			{
+				target = GTK_WIDGET(g_list_last(siblings)->data);
+			}
+			else if (!vertical
+					&& (kv == GDK_KEY_Right || kv == GDK_KEY_KP_Right)
+					&& at_last)
+			{
+				target = GTK_WIDGET(siblings->data);
+			}
+
+			g_list_free(siblings);
+
+			if (target && target != widget)
+			{
+				gtk_widget_grab_focus(target);
+				return GDK_EVENT_STOP;
 			}
 			return GDK_EVENT_PROPAGATE;
 		});

--- a/panel-plugin/launcher/page.cpp
+++ b/panel-plugin/launcher/page.cpp
@@ -27,6 +27,7 @@
 #include "settings.h"
 #include "ui/slot.h"
 #include "core/window.h"
+#include "core/window-keyboard.h"
 
 #include <libxfce4ui/libxfce4ui.h>
 
@@ -235,8 +236,38 @@ bool Page::remember_launcher(Launcher*)
 
 //-----------------------------------------------------------------------------
 
+bool Page::activate_first()
+{
+	GtkTreeModel* model = m_view ? m_view->get_model() : nullptr;
+	if (!model)
+	{
+		return false;
+	}
+	GtkTreeIter iter;
+	if (!gtk_tree_model_get_iter_first(model, &iter))
+	{
+		return false;
+	}
+	GtkTreePath* path = gtk_tree_model_get_path(model, &iter);
+	launcher_activated(path);
+	gtk_tree_path_free(path);
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+
 void Page::launcher_activated(GtkTreePath* path)
 {
+	// NOTE: 250 ms debounce against held-Enter key-repeat bursts (FR-022,
+	// SC-005). The state is process-global across pages because a single
+	// user keypress can only target one launcher at a time and a stuck
+	// key must not multi-launch.
+	static Keyboard::ActivationDebounce s_debounce;
+	if (!s_debounce.accept(g_get_monotonic_time()))
+	{
+		return;
+	}
+
 	GtkTreeIter iter;
 	GtkTreeModel* model = m_view->get_model();
 	gtk_tree_model_get_iter(model, &iter, path);

--- a/panel-plugin/launcher/page.h
+++ b/panel-plugin/launcher/page.h
@@ -60,6 +60,18 @@ public:
 	void select_first();
 	void update_view();
 
+	/* activate_first:
+	 *
+	 * Launches the launcher in the first row of the current view, if
+	 * the model has at least one row. Subject to the same activation
+	 * debounce as a mouse/key activation, so holding Enter on the
+	 * search entry cannot launch the same application twice. Used by
+	 * the search entry's "activate" handler to satisfy FR-021.
+	 *
+	 * Returns: true iff a row existed and was activated.
+	 */
+	bool activate_first();
+
 protected:
 	Window* get_window() const
 	{

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -48,6 +48,7 @@ plugin_sources = [
   'ui/slot.h',
   'core/window.cpp',
   'core/window-geometry.cpp',
+  'core/window-keyboard.cpp',
   'core/window-pages.cpp',
   xfce_revision_h,
   meowmenu_version_h,

--- a/panel-plugin/places/places-page.cpp
+++ b/panel-plugin/places/places-page.cpp
@@ -150,6 +150,26 @@ void PlacesPage::reload_view()
 
 //-----------------------------------------------------------------------------
 
+/* select_first:
+ * Select and scroll to the first item in the view, mirroring Page::select_first
+ * so callers that handle both Apps and Places mode can treat them uniformly.
+ */
+void PlacesPage::select_first()
+{
+	GtkTreeModel* model = m_view->get_model();
+	GtkTreeIter iter;
+	if (model && gtk_tree_model_get_iter_first(model, &iter))
+	{
+		GtkTreePath* path = gtk_tree_model_get_path(model, &iter);
+		m_view->set_cursor(path);
+		m_view->select_path(path);
+		m_view->scroll_to_path(path);
+		gtk_tree_path_free(path);
+	}
+}
+
+//-----------------------------------------------------------------------------
+
 void PlacesPage::set_active_section(PlacesSection* section)
 {
 	cancel_home_search();

--- a/panel-plugin/places/places-page.h
+++ b/panel-plugin/places/places-page.h
@@ -49,6 +49,7 @@ public:
 	void set_filter(const gchar* filter);
 	void refresh_active();
 	void reload_view();
+	void select_first();
 
 private:
 	void create_view();

--- a/panel-plugin/search/query.cpp
+++ b/panel-plugin/search/query.cpp
@@ -129,6 +129,34 @@ unsigned int Query::match(const std::string& haystack) const
 		return 0x80;
 	}
 
+	// Compact-form fallback for multi-token queries: rerun the
+	// prefix / word-boundary / substring tests with the query's
+	// internal whitespace stripped. Treats an accidentally-typed
+	// space inside a word (e.g. "fi le") as a typo so it can still
+	// reach "file manager" instead of dropping to zero results.
+	// Legitimate multi-word queries already matched above with a
+	// better (lower) score, so they are unaffected.
+	if (m_query_words.size() > 1)
+	{
+		std::string compact;
+		for (const auto& word : m_query_words)
+		{
+			compact += word;
+		}
+		if (compact.length() <= haystack.length())
+		{
+			const std::string::size_type cpos = haystack.find(compact);
+			if (cpos == 0)
+			{
+				return (haystack.length() == compact.length()) ? 0x4 : 0x8;
+			}
+			else if (cpos != std::string::npos)
+			{
+				return is_start_word(haystack, cpos) ? 0x10 : 0x80;
+			}
+		}
+	}
+
 	return UINT_MAX;
 }
 

--- a/panel-plugin/ui/launcher-icon-view.cpp
+++ b/panel-plugin/ui/launcher-icon-view.cpp
@@ -61,6 +61,34 @@ LauncherIconView::LauncherIconView(Settings* settings) :
 
 	// Handle hover selection
 	enable_hover_selection(GTK_WIDGET(m_view));
+
+	// FR-100: keep the focused item visible on programmatic cursor moves
+	// (Tab into Results, sidebar arrow exit). use_align=FALSE so an
+	// already-visible item does not jump.
+	connect(m_view, "focus-in-event",
+		[](GtkWidget* widget, GdkEvent*) -> gboolean
+		{
+			GtkIconView* iv = GTK_ICON_VIEW(widget);
+			GtkTreePath* path = nullptr;
+			gtk_icon_view_get_cursor(iv, &path, nullptr);
+			if (!path)
+			{
+				GList* sel = gtk_icon_view_get_selected_items(iv);
+				if (sel)
+				{
+					path = gtk_tree_path_copy(
+							static_cast<GtkTreePath*>(sel->data));
+				}
+				g_list_free_full(sel,
+						reinterpret_cast<GDestroyNotify>(&gtk_tree_path_free));
+			}
+			if (path)
+			{
+				gtk_icon_view_scroll_to_path(iv, path, FALSE, 0, 0);
+				gtk_tree_path_free(path);
+			}
+			return GDK_EVENT_PROPAGATE;
+		});
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/ui/launcher-tree-view.cpp
+++ b/panel-plugin/ui/launcher-tree-view.cpp
@@ -66,6 +66,34 @@ LauncherTreeView::LauncherTreeView(Settings* settings) :
 
 	gtk_style_context_add_class(gtk_widget_get_style_context(GTK_WIDGET(m_view)), "launchers");
 
+	// FR-100: bring the focused row into view without snap-scrolling on
+	// programmatic cursor moves (Tab into Results, arrow exit out of the
+	// sidebar). use_align=FALSE keeps the existing scroll position when
+	// the cursor row is already visible.
+	connect(m_view, "focus-in-event",
+		[](GtkWidget* widget, GdkEvent*) -> gboolean
+		{
+			GtkTreeView* tv = GTK_TREE_VIEW(widget);
+			GtkTreePath* path = nullptr;
+			gtk_tree_view_get_cursor(tv, &path, nullptr);
+			if (!path)
+			{
+				GtkTreeSelection* sel = gtk_tree_view_get_selection(tv);
+				GtkTreeIter iter;
+				if (gtk_tree_selection_get_selected(sel, nullptr, &iter))
+				{
+					path = gtk_tree_model_get_path(
+							gtk_tree_view_get_model(tv), &iter);
+				}
+			}
+			if (path)
+			{
+				gtk_tree_view_scroll_to_cell(tv, path, nullptr, FALSE, 0, 0);
+				gtk_tree_path_free(path);
+			}
+			return GDK_EVENT_PROPAGATE;
+		});
+
 	// Expand on click
 	connect(m_view, "row-activated",
 		[this](GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn*)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -172,3 +172,52 @@ test_home_search_lifecycle = executable(
 )
 
 test('home_search_lifecycle', test_home_search_lifecycle, timeout: 30)
+
+# test_focus_router: headless coverage of the Tab-cycle resolution
+# implemented in panel-plugin/core/window-keyboard.cpp. Pulls only the
+# helper translation unit; no display server, no GTK widgets.
+test_focus_router_sources = [
+  'test_focus_router.cpp',
+  '..' / 'panel-plugin' / 'core' / 'window-keyboard.cpp',
+]
+
+test_focus_router = executable(
+  'test_focus_router',
+  test_focus_router_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [glib, gtk],
+)
+
+test('focus_router', test_focus_router)
+
+# test_esc_ladder: headless coverage of the progressive Esc state
+# machine in panel-plugin/core/window-keyboard.cpp.
+test_esc_ladder_sources = [
+  'test_esc_ladder.cpp',
+  '..' / 'panel-plugin' / 'core' / 'window-keyboard.cpp',
+]
+
+test_esc_ladder = executable(
+  'test_esc_ladder',
+  test_esc_ladder_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [glib, gtk],
+)
+
+test('esc_ladder', test_esc_ladder)
+
+# test_key_routing: headless coverage of classify_key /
+# is_printable_for_search. Fabricates GdkEventKey values directly.
+test_key_routing_sources = [
+  'test_key_routing.cpp',
+  '..' / 'panel-plugin' / 'core' / 'window-keyboard.cpp',
+]
+
+test_key_routing = executable(
+  'test_key_routing',
+  test_key_routing_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [glib, gtk],
+)
+
+test('key_routing', test_key_routing)

--- a/tests/test_esc_ladder.cpp
+++ b/tests/test_esc_ladder.cpp
@@ -1,0 +1,132 @@
+/*
+ * Headless tests for the progressive Esc state machine declared in
+ * panel-plugin/core/window-keyboard.h.
+ *
+ * Covers contracts/esc-ladder.md §"Test plan".
+ */
+
+#include "core/window-keyboard.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using WhiskerMenu::Keyboard::classify_esc_state;
+using WhiskerMenu::Keyboard::esc_action;
+using WhiskerMenu::Keyboard::EscAction;
+using WhiskerMenu::Keyboard::EscState;
+
+namespace
+{
+
+int g_failures = 0;
+
+const char* state_name(EscState s)
+{
+	switch (s)
+	{
+	case EscState::ContextMenuOpen:  return "ContextMenuOpen";
+	case EscState::ResizeInProgress: return "ResizeInProgress";
+	case EscState::QueryNonEmpty:    return "QueryNonEmpty";
+	case EscState::MenuOpen:         return "MenuOpen";
+	}
+	return "?";
+}
+
+const char* action_name(EscAction a)
+{
+	switch (a)
+	{
+	case EscAction::CloseContextMenu: return "CloseContextMenu";
+	case EscAction::CancelResize:     return "CancelResize";
+	case EscAction::ClearQuery:       return "ClearQuery";
+	case EscAction::CloseMenu:        return "CloseMenu";
+	}
+	return "?";
+}
+
+#define EQS(actual, expected) do { \
+		EscState _a = (actual); \
+		EscState _e = (expected); \
+		if (_a != _e) { \
+			std::fprintf(stderr, "FAIL %s:%d: state got %s expected %s\n", \
+			             __FILE__, __LINE__, state_name(_a), state_name(_e)); \
+			++g_failures; \
+		} \
+	} while (0)
+
+#define EQA(actual, expected) do { \
+		EscAction _a = (actual); \
+		EscAction _e = (expected); \
+		if (_a != _e) { \
+			std::fprintf(stderr, "FAIL %s:%d: action got %s expected %s\n", \
+			             __FILE__, __LINE__, action_name(_a), action_name(_e)); \
+			++g_failures; \
+		} \
+	} while (0)
+
+void context_menu_wins()
+{
+	EQS(classify_esc_state(true, true, true), EscState::ContextMenuOpen);
+	EQA(esc_action(EscState::ContextMenuOpen), EscAction::CloseContextMenu);
+}
+
+void resize_wins_over_query()
+{
+	EQS(classify_esc_state(false, true, true), EscState::ResizeInProgress);
+	EQA(esc_action(EscState::ResizeInProgress), EscAction::CancelResize);
+}
+
+void query_wins_over_close()
+{
+	EQS(classify_esc_state(false, false, true), EscState::QueryNonEmpty);
+	EQA(esc_action(EscState::QueryNonEmpty), EscAction::ClearQuery);
+}
+
+void close_when_idle()
+{
+	EQS(classify_esc_state(false, false, false), EscState::MenuOpen);
+	EQA(esc_action(EscState::MenuOpen), EscAction::CloseMenu);
+}
+
+void four_press_progression()
+{
+	bool ctx = true, resize = true, query = true;
+
+	EscState s1 = classify_esc_state(ctx, resize, query);
+	EQS(s1, EscState::ContextMenuOpen);
+	EQA(esc_action(s1), EscAction::CloseContextMenu);
+	ctx = false;
+
+	EscState s2 = classify_esc_state(ctx, resize, query);
+	EQS(s2, EscState::ResizeInProgress);
+	EQA(esc_action(s2), EscAction::CancelResize);
+	resize = false;
+
+	EscState s3 = classify_esc_state(ctx, resize, query);
+	EQS(s3, EscState::QueryNonEmpty);
+	EQA(esc_action(s3), EscAction::ClearQuery);
+	query = false;
+
+	EscState s4 = classify_esc_state(ctx, resize, query);
+	EQS(s4, EscState::MenuOpen);
+	EQA(esc_action(s4), EscAction::CloseMenu);
+}
+
+} // namespace
+
+int main()
+{
+	context_menu_wins();
+	resize_wins_over_query();
+	query_wins_over_close();
+	close_when_idle();
+	four_press_progression();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_esc_ladder: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_esc_ladder: ok\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_focus_router.cpp
+++ b/tests/test_focus_router.cpp
@@ -1,0 +1,219 @@
+/*
+ * Headless tests for the Tab-cycle resolution helpers declared in
+ * panel-plugin/core/window-keyboard.h. No GTK widgets are instantiated;
+ * only the VisibilityMask/MenuState/Zone inputs are fabricated.
+ *
+ * Covers contracts/focus-router.md §"Test plan".
+ */
+
+#include "core/window-keyboard.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+using WhiskerMenu::Keyboard::Direction;
+using WhiskerMenu::Keyboard::MenuState;
+using WhiskerMenu::Keyboard::next_zone;
+using WhiskerMenu::Keyboard::VisibilityMask;
+using WhiskerMenu::Keyboard::Zone;
+using WhiskerMenu::Keyboard::zone_active;
+
+namespace
+{
+
+int g_failures = 0;
+
+#define CHECK(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			++g_failures; \
+		} \
+	} while (0)
+
+const char* zone_name(Zone z)
+{
+	switch (z)
+	{
+	case Zone::Search:  return "Search";
+	case Zone::Results: return "Results";
+	case Zone::Sidebar: return "Sidebar";
+	case Zone::Mode:    return "Mode";
+	case Zone::Profile: return "Profile";
+	}
+	return "?";
+}
+
+#define EQZ(actual, expected) do { \
+		Zone _a = (actual); \
+		Zone _e = (expected); \
+		if (_a != _e) { \
+			std::fprintf(stderr, "FAIL %s:%d: got %s expected %s\n", \
+			             __FILE__, __LINE__, zone_name(_a), zone_name(_e)); \
+			++g_failures; \
+		} \
+	} while (0)
+
+void canonical_forward_all_visible()
+{
+	VisibilityMask mask;
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Forward),
+	    Zone::Results);
+}
+
+void canonical_full_loop()
+{
+	VisibilityMask mask;
+	Zone z = Zone::Search;
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Results);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Sidebar);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Mode);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Profile);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Search);
+}
+
+void reverse_full_loop()
+{
+	VisibilityMask mask;
+	Zone z = Zone::Search;
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Profile);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Mode);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Sidebar);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Results);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Search);
+	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Profile);
+}
+
+void sidebar_skipped_when_searching()
+{
+	VisibilityMask mask;
+	EQZ(next_zone(mask, MenuState::Searching, Zone::Results, Direction::Forward),
+	    Zone::Mode);
+}
+
+void sidebar_rejoined_when_browsing()
+{
+	VisibilityMask mask;
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Results, Direction::Forward),
+	    Zone::Sidebar);
+}
+
+void hidden_profile_skipped()
+{
+	VisibilityMask mask;
+	mask.profile = false;
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Mode, Direction::Forward),
+	    Zone::Search);
+}
+
+void hidden_sidebar_and_mode()
+{
+	VisibilityMask mask;
+	mask.sidebar = false;
+	mask.mode = false;
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Results, Direction::Forward),
+	    Zone::Profile);
+}
+
+void hidden_profile_and_mode_searching()
+{
+	VisibilityMask mask;
+	mask.profile = false;
+	mask.mode = false;
+	EQZ(next_zone(mask, MenuState::Searching, Zone::Results, Direction::Forward),
+	    Zone::Search);
+}
+
+void current_is_inert_zone()
+{
+	// Sidebar just became inert (user typed first character). Forward
+	// from inert Sidebar should land on the first active zone after it
+	// in canonical order, which is Mode.
+	VisibilityMask mask;
+	EQZ(next_zone(mask, MenuState::Searching, Zone::Sidebar, Direction::Forward),
+	    Zone::Mode);
+}
+
+void ltr_and_rtl_equivalence()
+{
+	// The cycle is independent of widget default direction (FR-120);
+	// the function takes no GTK state. Pin the property explicitly by
+	// running the same call twice with identical inputs and asserting
+	// the same output.
+	VisibilityMask mask;
+	Zone ltr = next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Forward);
+	Zone rtl = next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Forward);
+	EQZ(ltr, rtl);
+}
+
+void four_tabs_visit_every_visible()
+{
+	// SC-006: starting from Search in an all-visible Browsing menu,
+	// four Forward Tab steps must visit Results, Sidebar, Mode, Profile.
+	VisibilityMask mask;
+	bool visited[5] = { false, false, false, false, false };
+	Zone z = Zone::Search;
+	visited[static_cast<unsigned>(z)] = true;
+	for (int i = 0; i < 4; ++i)
+	{
+		z = next_zone(mask, MenuState::Browsing, z, Direction::Forward);
+		visited[static_cast<unsigned>(z)] = true;
+	}
+	for (unsigned i = 0; i < 5; ++i)
+	{
+		CHECK(visited[i]);
+	}
+}
+
+void all_optional_zones_hidden()
+{
+	// Profile + Mode + Sidebar hidden → cycle reduces to Search ↔ Results.
+	VisibilityMask mask;
+	mask.sidebar = false;
+	mask.mode = false;
+	mask.profile = false;
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Forward),
+	    Zone::Results);
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Results, Direction::Forward),
+	    Zone::Search);
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Backward),
+	    Zone::Results);
+}
+
+void zone_active_basic()
+{
+	VisibilityMask mask;
+	CHECK(zone_active(Zone::Sidebar, mask, MenuState::Browsing));
+	CHECK(!zone_active(Zone::Sidebar, mask, MenuState::Searching));
+	mask.profile = false;
+	CHECK(!zone_active(Zone::Profile, mask, MenuState::Browsing));
+	CHECK(zone_active(Zone::Search, mask, MenuState::Searching));
+	CHECK(zone_active(Zone::Results, mask, MenuState::Searching));
+}
+
+} // namespace
+
+int main()
+{
+	canonical_forward_all_visible();
+	canonical_full_loop();
+	reverse_full_loop();
+	sidebar_skipped_when_searching();
+	sidebar_rejoined_when_browsing();
+	hidden_profile_skipped();
+	hidden_sidebar_and_mode();
+	hidden_profile_and_mode_searching();
+	current_is_inert_zone();
+	ltr_and_rtl_equivalence();
+	four_tabs_visit_every_visible();
+	all_optional_zones_hidden();
+	zone_active_basic();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_focus_router: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_focus_router: ok\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_key_routing.cpp
+++ b/tests/test_key_routing.cpp
@@ -1,0 +1,237 @@
+/*
+ * Headless tests for classify_key / is_printable_for_search declared in
+ * panel-plugin/core/window-keyboard.h. Fabricates GdkEventKey values
+ * directly; no display server required.
+ *
+ * Covers contracts/key-routing.md §"Test plan".
+ */
+
+#include "core/window-keyboard.h"
+
+#include <gdk/gdk.h>
+#include <gdk/gdkkeysyms.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using WhiskerMenu::Keyboard::classify_key;
+using WhiskerMenu::Keyboard::is_printable_for_search;
+using WhiskerMenu::Keyboard::KeyClass;
+
+namespace
+{
+
+int g_failures = 0;
+
+const char* class_name(KeyClass c)
+{
+	switch (c)
+	{
+	case KeyClass::ImeComposition:  return "ImeComposition";
+	case KeyClass::ModifierOnly:    return "ModifierOnly";
+	case KeyClass::FunctionUtility: return "FunctionUtility";
+	case KeyClass::Printable:       return "Printable";
+	}
+	return "?";
+}
+
+#define EQC(actual, expected) do { \
+		KeyClass _a = (actual); \
+		KeyClass _e = (expected); \
+		if (_a != _e) { \
+			std::fprintf(stderr, "FAIL %s:%d: got %s expected %s\n", \
+			             __FILE__, __LINE__, class_name(_a), class_name(_e)); \
+			++g_failures; \
+		} \
+	} while (0)
+
+GdkEventKey make_event(guint keyval, guint state = 0, bool is_modifier = false)
+{
+	GdkEventKey e;
+	std::memset(&e, 0, sizeof(e));
+	e.type = GDK_KEY_PRESS;
+	e.keyval = keyval;
+	e.state = state;
+	e.is_modifier = is_modifier ? 1 : 0;
+	return e;
+}
+
+void letter_is_printable()
+{
+	GdkEventKey e = make_event(GDK_KEY_a);
+	EQC(classify_key(&e), KeyClass::Printable);
+}
+
+void space_is_printable()
+{
+	// FR-010: Space must extend the query, not toggle Mode.
+	GdkEventKey e = make_event(GDK_KEY_space);
+	EQC(classify_key(&e), KeyClass::Printable);
+}
+
+void shift_letter_is_printable()
+{
+	GdkEventKey e = make_event(GDK_KEY_A, GDK_SHIFT_MASK);
+	EQC(classify_key(&e), KeyClass::Printable);
+}
+
+void ctrl_letter_not_printable()
+{
+	GdkEventKey e = make_event(GDK_KEY_a, GDK_CONTROL_MASK);
+	KeyClass c = classify_key(&e);
+	// Ctrl+letter must NOT be routed; either FunctionUtility (because
+	// Ctrl held disables printable test) or ModifierOnly is acceptable.
+	if (c == KeyClass::Printable)
+	{
+		std::fprintf(stderr, "FAIL %s:%d: ctrl_letter classified Printable\n",
+		             __FILE__, __LINE__);
+		++g_failures;
+	}
+}
+
+void f5_is_function()
+{
+	GdkEventKey e = make_event(GDK_KEY_F5);
+	EQC(classify_key(&e), KeyClass::FunctionUtility);
+}
+
+void delete_is_function()
+{
+	GdkEventKey e = make_event(GDK_KEY_Delete);
+	EQC(classify_key(&e), KeyClass::FunctionUtility);
+}
+
+void arrow_keys_are_function()
+{
+	const guint arrows[] = { GDK_KEY_Up, GDK_KEY_Down, GDK_KEY_Left, GDK_KEY_Right };
+	for (guint kv : arrows)
+	{
+		GdkEventKey e = make_event(kv);
+		EQC(classify_key(&e), KeyClass::FunctionUtility);
+	}
+}
+
+void home_end_pageup_pagedown_function()
+{
+	const guint navs[] = { GDK_KEY_Home, GDK_KEY_End, GDK_KEY_Page_Up, GDK_KEY_Page_Down };
+	for (guint kv : navs)
+	{
+		GdkEventKey e = make_event(kv);
+		EQC(classify_key(&e), KeyClass::FunctionUtility);
+	}
+}
+
+void menu_key_is_function()
+{
+	GdkEventKey e = make_event(GDK_KEY_Menu);
+	EQC(classify_key(&e), KeyClass::FunctionUtility);
+}
+
+void shift_alone_modifier()
+{
+	GdkEventKey e = make_event(GDK_KEY_Shift_L, 0, true);
+	EQC(classify_key(&e), KeyClass::ModifierOnly);
+}
+
+void iso_level3_modifier()
+{
+	GdkEventKey e = make_event(GDK_KEY_ISO_Level3_Shift);
+	EQC(classify_key(&e), KeyClass::ModifierOnly);
+}
+
+void ime_composition_marked()
+{
+	GdkEventKey e = make_event(GDK_KEY_a, GDK_MODIFIER_RESERVED_25_MASK);
+	EQC(classify_key(&e), KeyClass::ImeComposition);
+}
+
+void control_keys_not_printable()
+{
+	// Tab, Return, Escape, Backspace all map to control codepoints
+	// through gdk_keyval_to_unicode (0x09, 0x0d, 0x1b, 0x08). They
+	// must NOT be classified Printable — each has a dedicated
+	// dispatch path and routing them into the entry would corrupt
+	// the query (FR-010, FR-013, FR-021, FR-060).
+	const guint controls[] = {
+		GDK_KEY_Tab, GDK_KEY_ISO_Left_Tab,
+		GDK_KEY_Return, GDK_KEY_KP_Enter,
+		GDK_KEY_Escape,
+		GDK_KEY_BackSpace,
+	};
+	for (guint kv : controls)
+	{
+		GdkEventKey e = make_event(kv);
+		KeyClass c = classify_key(&e);
+		if (c == KeyClass::Printable)
+		{
+			std::fprintf(stderr, "FAIL %s:%d: keyval %u classified Printable\n",
+			             __FILE__, __LINE__, kv);
+			++g_failures;
+		}
+	}
+}
+
+void non_latin_printable()
+{
+	// CJK "中" — U+4E2D. GDK encodes Unicode keysyms as
+	// 0x01000000 | codepoint (see gdk_keyval_to_unicode in GDK).
+	GdkEventKey e = make_event(0x01000000u | 0x4E2Du);
+	EQC(classify_key(&e), KeyClass::Printable);
+}
+
+void null_event_safe()
+{
+	// Defensive: classify_key MUST be a total function and tolerate
+	// a NULL pointer without crashing.
+	(void)classify_key(nullptr);
+	(void)is_printable_for_search(nullptr);
+}
+
+void convenience_predicate_matches()
+{
+	GdkEventKey letter = make_event(GDK_KEY_a);
+	if (!is_printable_for_search(&letter))
+	{
+		std::fprintf(stderr, "FAIL %s:%d: is_printable_for_search(a) false\n",
+		             __FILE__, __LINE__);
+		++g_failures;
+	}
+	GdkEventKey f5 = make_event(GDK_KEY_F5);
+	if (is_printable_for_search(&f5))
+	{
+		std::fprintf(stderr, "FAIL %s:%d: is_printable_for_search(F5) true\n",
+		             __FILE__, __LINE__);
+		++g_failures;
+	}
+}
+
+} // namespace
+
+int main()
+{
+	letter_is_printable();
+	space_is_printable();
+	shift_letter_is_printable();
+	ctrl_letter_not_printable();
+	f5_is_function();
+	delete_is_function();
+	arrow_keys_are_function();
+	home_end_pageup_pagedown_function();
+	menu_key_is_function();
+	shift_alone_modifier();
+	iso_level3_modifier();
+	ime_composition_marked();
+	control_keys_not_printable();
+	non_latin_printable();
+	null_event_safe();
+	convenience_predicate_matches();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_key_routing: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_key_routing: ok\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_search_ranking.cpp
+++ b/tests/test_search_ranking.cpp
@@ -98,6 +98,39 @@ void test_match_mid_word_substring()
 	assert(s == 0x80 && "mid-word substring must score 0x80");
 }
 
+void test_match_accidental_space_in_word_compact_fallback()
+{
+	// User typed an accidental space inside a single intended word.
+	// Each whitespace-delimited token fails the word-boundary tests
+	// ("le" lands mid-word inside "file"), but the compact form
+	// "file" matches at a word boundary in the haystack — the
+	// regression fix for the space-as-printable-char behaviour.
+	Query q("fi le");
+	const unsigned int s = q.match("thunar file manager");
+	assert(s == 0x10 && "compact-form fallback must restore word-boundary score");
+}
+
+void test_match_accidental_space_prefix_compact_fallback()
+{
+	// Accidental space splits an intended prefix. Compact form "file"
+	// is a strict prefix of "file manager", so it must score as a
+	// prefix match (0x8), not exact (0x4) — lengths differ.
+	Query q("fi le");
+	const unsigned int s = q.match("file manager");
+	assert(s == 0x8 && "compact form that is a prefix must score 0x8");
+}
+
+void test_match_legitimate_multiword_unaffected_by_compact_fallback()
+{
+	// Genuine multi-word query must continue to land on the
+	// word-boundary in-order branch (0x20), not on the compact-form
+	// fallback. Freezes the precedence so the new fallback never
+	// poaches matches that the existing branches already serve.
+	Query q("file utility");
+	const unsigned int s = q.match("file manager utility");
+	assert(s == 0x20 && "legitimate multi-word query must keep its 0x20 score");
+}
+
 void test_match_no_match_returns_uintmax()
 {
 	Query q("nothing");
@@ -220,6 +253,9 @@ int main()
 	test_match_mid_word_substring();
 	test_match_no_match_returns_uintmax();
 	test_match_case_insensitive_via_casefold();
+	test_match_accidental_space_in_word_compact_fallback();
+	test_match_accidental_space_prefix_compact_fallback();
+	test_match_legitimate_multiword_unaffected_by_compact_fallback();
 
 	test_match_as_characters_start_words();
 	test_match_as_characters_scattered();


### PR DESCRIPTION
- Full keyboard navigation: open menu, type, press Enter to launch — no mouse required
- Tab cycles through all visible zones (Search → Results → Sidebar → Mode → Profile)
- Arrow keys navigate within each zone; Esc peels one layer at a time (context menu → clear query → close)
- Apps/Places mode switch and session buttons (Lock, Log out…) reachable via keyboard
- Shift+F10 / Menu key opens context menus from the keyboard
- Focus indicator visible on every widget during keyboard traversal
- Protection against double-launch on held Enter
- IME/CJK input, RTL layouts, and Wayland focus-steal fully supported
- Fix: Tab and arrow navigation no longer get stuck when Places mode is active