### PR TITLE
Release 0.5.4

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,11 @@
 MEOW MENU DEVELOPMENT
+0.5.4 (2026-06-01)
+=====
+- Tab now switches directly between Applications and Places
+- Ctrl+Tab cycles focus areas (zones)
+- show missing Places items as muted, with their Open action disabled
+- keep "Open containing folder" available for missing items
+
 0.5.3 (2026-05-29)
 =====
 - enable keyboard navigation

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ project that originated as a fork of [Whisker Menu](https://gitlab.xfce.org/pane
 and keeps the familiar panel-launcher feel while bringing a cleaner modern
 look and more customization options.
 
-**Fully keyboard-driven** — every zone (search, results, sidebar, mode
-switch, session buttons) is reachable without the mouse. See
-[Keyboard navigation](docs/keyboard-navigation.md) for the complete
-shortcut reference.
+**Fully keyboard-driven** — **Tab** switches Applications/Places,
+**Ctrl+Tab** moves between areas, and the arrows move within them. See
+[Keyboard navigation](docs/keyboard-navigation.md) for the full reference.
 
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,15 @@ All MeowMenu settings are exposed in the **Properties** dialog
 | Remember last mode | Reopen MeowMenu showing the last-used Places sub-section. |
 | Show metadata | Display file size and modification date next to each item. |
 
+#### Missing recent files and bookmarks
+
+When a recent item or bookmark points to a file or folder that has been deleted
+or renamed, MeowMenu shows it greyed-out and its tooltip notes that the target
+is missing. A greyed-out entry cannot be opened directly — clicking it does
+nothing — but its right-click menu still offers **Open Containing Folder**,
+which opens the parent directory so a renamed file can be located. Missing
+bookmarks can also be removed with **Remove from Favourites**.
+
 ## Xfconf reference
 
 For scripting or headless configuration, read and write settings directly

--- a/docs/keyboard-navigation.md
+++ b/docs/keyboard-navigation.md
@@ -7,99 +7,65 @@ has_children: false
 
 # Keyboard navigation
 
-MeowMenu is fully keyboard-driven. Every visible area — search box,
-results, sidebar categories, the Apps/Places switch, and the session
-buttons — can be reached and operated without touching the mouse.
-
-This page lists the shortcuts that work on every preset and on both
+MeowMenu can be driven entirely from the keyboard: open it, start typing,
+or use the keys below. These shortcuts work on every preset and on both
 X11 and Wayland.
 
 ## Quick reference
 
 | Key                  | Effect                                                                  |
 |----------------------|-------------------------------------------------------------------------|
-| Type any letter      | Starts (or extends) a search query — focus jumps to the search box.     |
-| Space                | While searching, inserts a space into the query (it does not "click").  |
-| `Backspace`          | Removes the last character from the query. Stops at the empty query.    |
-| `Enter`              | Launches the highlighted item; on the search box, launches the first match. |
-| `Tab` / `Shift+Tab`  | Cycles focus between zones: Search → Results → Sidebar → Apps/Places → Session buttons (and back). |
-| `↑` / `↓`            | Moves the selection one row up or down inside the current list.         |
-| `Page Up` / `Page Down` | Moves the selection by one visible page inside the list.             |
-| `Home` / `End`       | Jumps to the first / last item inside the current list or sidebar.      |
-| `←` / `→`            | Inside the sidebar: exits to the results. Inside the results: exits to the sidebar (only while not searching). |
-| `Esc`                | Closes context menus, then cancels a resize, then clears the query, then closes the menu. |
-| `Shift+F10` or `Menu`| Opens the context menu for the highlighted launcher.                    |
+| Type any letter      | Starts or extends a search — focus jumps to the search box.             |
+| `Enter`              | Launches the highlighted item (the first match on the search box).      |
+| `Backspace`          | Deletes the last character of the query.                                |
+| `Tab` / `Shift+Tab`  | Switches between **Applications** and **Places** (when Places is on).   |
+| `Ctrl+Tab` / `Ctrl+Shift+Tab` | Moves focus through the areas: Search → Results → Sidebar → Session buttons (and back). |
+| `↑` / `↓`            | Moves the selection inside the current list.                            |
+| `Page Up` / `Page Down` | Moves the selection one screenful at a time.                         |
+| `Home` / `End`       | Jumps to the first / last item.                                         |
+| `←` / `→`            | Crosses between the sidebar and the results (only while not searching). |
+| `Esc`                | Steps back one level (see below).                                       |
+| `Shift+F10` or `Menu`| Opens the context menu for the highlighted item.                        |
 
-## Tab order
+## Switching Applications and Places
 
-Pressing `Tab` walks the menu in a fixed logical order:
+`Tab` and `Shift+Tab` switch between **Applications** and **Places** from
+anywhere in the menu. The new view opens on its default content
+(Applications → your default category, Places → Home) with focus on the
+results, ready to arrow. When Places is disabled, `Tab` does nothing.
 
-1. **Search box** — always the first stop.
-2. **Results list** — current category or search results.
-3. **Sidebar** — category buttons. Skipped while a query is active.
-4. **Apps / Places switch** — only present when Places is enabled.
-5. **Session buttons** — lock, logout, suspend, etc.
+## Moving between areas
 
-`Shift+Tab` walks the same cycle in reverse. Zones that are hidden by
-the current preset (for example, no profile bar) are skipped silently.
+`Ctrl+Tab` moves focus through the areas in order — Search → Results →
+Sidebar → Session buttons — and `Ctrl+Shift+Tab` goes back. Hidden areas
+are skipped, and the sidebar is skipped while you are searching.
 
-## Inside each zone
+> Some desktops bind `Ctrl+Tab` globally; where they do, the menu never
+> receives it and area cycling is unavailable.
 
-**Sidebar.** `↑` / `↓` (or `←` / `→` when the sidebar is horizontal)
-move between categories and wrap at the ends. `Home` / `End` jump to
-the first / last category. The arrow that points toward the results
-exits the sidebar; the opposite arrow does nothing.
+## Moving within an area
 
-**Results list.** `↑` / `↓` move row by row (no wrap). `Page Up` /
-`Page Down` move one screenful at a time. `Home` / `End` jump to the
-first / last item. `Enter` launches.
-
-**Apps / Places switch.** Any arrow key flips to the other side. The
-arrow that points toward the search box does **not** flip — use `Tab`
-to leave. `Space` is treated as a normal space character when you are
-typing, so it does not toggle the switch.
-
-**Session buttons.** `←` / `→` move between visible buttons (no wrap).
-`Enter` (or `Space`) activates the focused button. `↑` / `↓` do
-nothing inside this strip.
+- **Results / Sidebar** — `↑` / `↓` move the selection; `Home` / `End`
+  jump to the ends. The sidebar wraps and also takes `←` / `→` when it is
+  laid out horizontally.
+- **Sidebar ↔ Results** — the arrow pointing toward the results leaves the
+  sidebar, and the opposite arrow returns (only while not searching).
+- **Session buttons** — `←` / `→` move between buttons; `Enter` activates.
 
 ## The `Esc` ladder
 
-A single press peels exactly one layer, in this strict order:
+One press undoes one thing, in this order: close an open context menu →
+cancel a resize → clear the search text → close the menu.
 
-1. If a right-click context menu is open, close just that menu.
-2. Otherwise, if a window resize is in progress, cancel the resize and
-   restore the previous size.
-3. Otherwise, if the search box contains text, clear the query.
-4. Otherwise, close the menu.
+## Type to search
 
-`Backspace` and `Delete` never close the menu — only `Esc` (or the
-configured global toggle shortcut) does.
+Start typing at any time. Letters, digits, punctuation, and emoji all go
+to the search box, wherever focus is; non-text keys are left untouched.
+In-progress input-method (CJK) composition is preserved.
 
-## Type-to-search
+## Notes
 
-You can start typing at any time. Letters, digits, punctuation, and
-emoji are all routed into the search box, regardless of which zone
-holds focus. Keys that do not produce text (`Shift`, `Ctrl`, function
-keys, arrow keys, `Insert`, `Delete`…) are passed through to the
-focused widget unchanged.
-
-The redirect respects active input-method composition: a half-typed
-Japanese / Chinese / Korean character is finished where it was
-started, not in the search box.
-
-## RTL languages
-
-The logical Tab order (Search → Results → Sidebar → Switch → Buttons)
-is the same in RTL locales such as Arabic and Hebrew. Only the visual
-direction of the sidebar-exit arrow is mirrored, so the arrow always
-points the right way on screen.
-
-## Wayland note
-
-On Wayland the layer-shell preset keeps the menu open even when focus
-moves to another window briefly (for example, when a notification
-takes focus). Close the menu the way you opened it (the global
-shortcut) or press `Esc`.
-
-[Back to top](#keyboard-navigation)
+- The area order is identical in right-to-left locales; only the
+  sidebar-exit arrow is mirrored visually.
+- On Wayland (layer-shell preset) the menu stays open if focus briefly
+  leaves it — close it with `Esc` or your global shortcut.

--- a/panel-plugin/core/window-keyboard.cpp
+++ b/panel-plugin/core/window-keyboard.cpp
@@ -32,7 +32,6 @@ bool zone_active(Zone z, VisibilityMask mask, MenuState state)
 	case Zone::Search:  visible = mask.search;  break;
 	case Zone::Results: visible = mask.results; break;
 	case Zone::Sidebar: visible = mask.sidebar; break;
-	case Zone::Mode:    visible = mask.mode;    break;
 	case Zone::Profile: visible = mask.profile; break;
 	}
 	if (!visible)
@@ -70,7 +69,7 @@ Zone next_zone(VisibilityMask mask,
 	// `current` is itself inert (e.g. the user just typed and Sidebar
 	// went inert mid-cycle) the anchor remains its canonical position,
 	// so the next active zone after Sidebar in Forward direction is
-	// Mode — matching contracts/focus-router.md row `current_is_inert_zone`.
+	// Profile (the mode toggle is no longer a cycle stop, FR-007).
 	std::size_t anchor = 0;
 	for (std::size_t k = 0; k < N; ++k)
 	{
@@ -91,6 +90,11 @@ Zone next_zone(VisibilityMask mask,
 	}
 
 	return current;
+}
+
+TabAction tab_action(bool places_available)
+{
+	return places_available ? TabAction::ToggleMode : TabAction::Inert;
 }
 
 EscState classify_esc_state(bool context_menu_open,

--- a/panel-plugin/core/window-keyboard.h
+++ b/panel-plugin/core/window-keyboard.h
@@ -28,19 +28,20 @@ namespace WhiskerMenu
 namespace Keyboard
 {
 
-/* Logical focusable region of the menu. The cycle order used by Tab /
- * Shift+Tab is the declared numeric order below; see CANONICAL_CYCLE. */
+/* Logical focusable region of the menu. The cycle order used by Ctrl+Tab /
+ * Ctrl+Shift+Tab is the declared numeric order below; see CANONICAL_CYCLE.
+ * The Apps/Places mode toggle is deliberately absent: it is operated by Tab
+ * and is never a keyboard-focusable cycle stop (FR-007). */
 enum class Zone : unsigned
 {
 	Search  = 0,
 	Results = 1,
 	Sidebar = 2,
-	Mode    = 3,
-	Profile = 4,
+	Profile = 3,
 };
 
 /* Reflects whether the user is currently typing a query. The sidebar is
- * inert (skipped from the Tab cycle) while Searching. */
+ * inert (skipped from the Ctrl+Tab cycle) while Searching. */
 enum class MenuState : unsigned
 {
 	Browsing,
@@ -53,6 +54,27 @@ enum class Direction : unsigned
 	Backward,
 };
 
+/* What a bare Tab / Shift+Tab press does. Encodes FR-006: Tab always means
+ * "switch Applications/Places" and never silently becomes area cycling. */
+enum class TabAction : unsigned
+{
+	ToggleMode,  // Places is available — flip Apps⇄Places
+	Inert,       // Places unavailable — do nothing, consume the event
+};
+
+/* tab_action:
+ * @places_available: whether the Places mode is enabled and thus a valid
+ *                    target for the toggle (Window::m_settings->places_enabled).
+ *
+ * Pure, total, side-effect-free decision for a bare Tab/Shift+Tab press.
+ * Keeping it a free function lets the FR-006 invariant be unit-tested
+ * without instantiating any GTK widgets.
+ *
+ * Returns: TabAction::ToggleMode when Places is available, otherwise
+ * TabAction::Inert.
+ */
+TabAction tab_action(bool places_available);
+
 /* Per-zone visibility mask folded from the existing m_layout_* flags
  * and the preset's per-zone "hidden" positions. Search and Results
  * are forced visible per FR-030. */
@@ -61,15 +83,16 @@ struct VisibilityMask
 	bool search  = true;
 	bool results = true;
 	bool sidebar = true;
-	bool mode    = true;
 	bool profile = true;
 };
 
-/* Canonical, locale-independent Tab cycle order (FR-030, FR-031). RTL
- * does not reverse it; arrow keys handle visual direction separately
- * (FR-120). */
-constexpr std::array<Zone, 5> CANONICAL_CYCLE = {
-	Zone::Search, Zone::Results, Zone::Sidebar, Zone::Mode, Zone::Profile,
+/* Canonical, locale-independent focus-area cycle order, walked by Ctrl+Tab
+ * (Forward) and Ctrl+Shift+Tab (Backward). RTL does not reverse it; arrow
+ * keys handle visual direction separately (FR-120). The Apps/Places mode
+ * toggle is intentionally NOT a member: it is operated by Tab and is never
+ * a cycle stop (FR-007). */
+constexpr std::array<Zone, 4> CANONICAL_CYCLE = {
+	Zone::Search, Zone::Results, Zone::Sidebar, Zone::Profile,
 };
 
 /* zone_active:
@@ -89,7 +112,7 @@ bool zone_active(Zone z, VisibilityMask mask, MenuState state);
  * @current: currently focused zone (may itself be inert/hidden — treated
  *           as a virtual position before filtered[0] going Forward, or
  *           after filtered[N-1] going Backward).
- * @direction: Forward for Tab, Backward for Shift+Tab.
+ * @direction: Forward for Ctrl+Tab, Backward for Ctrl+Shift+Tab.
  *
  * Returns the next zone to receive focus, walking CANONICAL_CYCLE with
  * the inactive zones filtered out and wrapping around at the ends.

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -559,34 +559,13 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 				gtk_toggle_button_set_active(b, true);
 		});
 
-	// FR-041 / FR-081: any arrow key on a mode toggle flips to the
-	// opposite toggle. Space is NOT bound (clarification Q1) — it falls
-	// through and is captured by the printable-key catch-all so it
-	// extends the query, matching FR-080. Key repeat is absorbed by
-	// m_mode_switch_in_progress inside switch_mode().
-	auto mode_arrow_handler = [this](GtkWidget*, GdkEvent* ev) -> gboolean
-	{
-		GdkEventKey* key = reinterpret_cast<GdkEventKey*>(ev);
-		switch (key->keyval)
-		{
-		case GDK_KEY_Left:  case GDK_KEY_KP_Left:
-		case GDK_KEY_Right: case GDK_KEY_KP_Right:
-		case GDK_KEY_Up:    case GDK_KEY_KP_Up:
-		case GDK_KEY_Down:  case GDK_KEY_KP_Down:
-			break;
-		default:
-			return GDK_EVENT_PROPAGATE;
-		}
-		const bool currently_places
-				= gtk_toggle_button_get_active(m_mode_btn_places);
-		GtkToggleButton* target = currently_places
-				? m_mode_btn_apps : m_mode_btn_places;
-		gtk_toggle_button_set_active(target, true);
-		gtk_widget_grab_focus(GTK_WIDGET(target));
-		return GDK_EVENT_STOP;
-	};
-	connect(m_mode_btn_apps,   "key-press-event", mode_arrow_handler);
-	connect(m_mode_btn_places, "key-press-event", mode_arrow_handler);
+	// The Apps/Places mode is now operated solely by Tab/Shift+Tab and is
+	// never a keyboard-focus stop (FR-007). Make both toggle buttons
+	// non-focusable so GTK's own Tab traversal can never land on them and
+	// so no arrow-key mode flip is possible from them; mouse activation
+	// via the "toggled" handlers above is unaffected.
+	gtk_widget_set_can_focus(GTK_WIDGET(m_mode_btn_apps),   FALSE);
+	gtk_widget_set_can_focus(GTK_WIDGET(m_mode_btn_places), FALSE);
 
 	// Create search results
 	m_search_results = new SearchPage(m_settings, this);
@@ -1341,9 +1320,10 @@ Keyboard::VisibilityMask WhiskerMenu::Window::current_visibility_mask() const
 {
 	// FR-030: Search and Results are never hidden. Optional zones follow
 	// the preset's per-zone "hidden" position string and the legacy
-	// visibility flags. Mode is the Apps/Places selector and is gated on
-	// places_enabled; Profile is the session-button row and is gated on
-	// commands_position != "hidden" with at least one visible command.
+	// visibility flags. Profile is the session-button row and is gated on
+	// commands_position != "hidden" with at least one visible command. The
+	// Apps/Places toggle is not a focus zone (FR-007), so it has no entry
+	// here; Tab reads places_enabled directly.
 	Keyboard::VisibilityMask mask;
 	mask.search  = true;
 	mask.results = true;
@@ -1352,7 +1332,6 @@ Keyboard::VisibilityMask WhiskerMenu::Window::current_visibility_mask() const
 	const char* commands_pos = m_settings->commands_position;
 
 	mask.sidebar = (g_strcmp0(sidebar_pos, "hidden") != 0);
-	mask.mode    = m_settings->places_enabled;
 
 	bool any_command_visible = false;
 	if (g_strcmp0(commands_pos, "hidden") != 0)
@@ -1421,19 +1400,6 @@ void WhiskerMenu::Window::grab_focus_in_zone(Keyboard::Zone zone)
 		target = const_cast<Window*>(this)->get_active_category_button();
 		break;
 
-	case Keyboard::Zone::Mode:
-		// Focus the active mode toggle so the arrow-toggle handler in
-		// window-pages.cpp can flip from there (FR-041, FR-081).
-		if (m_mode_btn_places && gtk_toggle_button_get_active(m_mode_btn_places))
-		{
-			target = GTK_WIDGET(m_mode_btn_places);
-		}
-		else if (m_mode_btn_apps)
-		{
-			target = GTK_WIDGET(m_mode_btn_apps);
-		}
-		break;
-
 	case Keyboard::Zone::Profile:
 		// First visible+focusable command button in physical box order.
 		for (int i = 0; i < 9; ++i)
@@ -1485,7 +1451,8 @@ Keyboard::Zone WhiskerMenu::Window::current_zone() const
 		return Keyboard::Zone::Search;
 	}
 
-	GtkWidget* mode_box  = m_mode_selector_box  ? GTK_WIDGET(m_mode_selector_box)  : nullptr;
+	// NOTE: the Apps/Places toggle box is intentionally not matched here:
+	// its buttons are non-focusable (FR-007) so focus can never rest in it.
 	GtkWidget* sidebar   = m_sidebar            ? GTK_WIDGET(m_sidebar)            : nullptr;
 	GtkWidget* cats_box  = m_categories_box     ? GTK_WIDGET(m_categories_box)     : nullptr;
 	GtkWidget* cmds_box  = m_commands_box       ? GTK_WIDGET(m_commands_box)       : nullptr;
@@ -1493,8 +1460,6 @@ Keyboard::Zone WhiskerMenu::Window::current_zone() const
 
 	for (GtkWidget* w = focused; w; w = gtk_widget_get_parent(w))
 	{
-		if (mode_box && w == mode_box)
-			return Keyboard::Zone::Mode;
 		if (cmds_box && w == cmds_box)
 			return Keyboard::Zone::Profile;
 		if (sidebar && w == sidebar)
@@ -1537,28 +1502,53 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEventKey*
 		}
 	}
 
-	// Tab / Shift+Tab → canonical zone cycling (FR-030, FR-031, FR-032).
-	// Intercepted before GTK's default focus-chain so we can skip inert
-	// zones (Sidebar while Searching) and follow the canonical order
-	// regardless of layout-mode reorderings of the underlying box tree.
+	// Tab family is intercepted before GTK's default focus-chain and split
+	// on the Control modifier:
+	//   - bare Tab / Shift+Tab        → Applications⇄Places mode toggle
+	//                                    (FR-001, FR-002, FR-006);
+	//   - Ctrl+Tab / Ctrl+Shift+Tab   → canonical focus-area cycling
+	//                                    (FR-004, FR-005, FR-007).
+	// The two are mutually exclusive on GDK_CONTROL_MASK and both always
+	// consume the event so GTK's own Tab traversal never also fires.
 	if (key_event->keyval == GDK_KEY_Tab
 			|| key_event->keyval == GDK_KEY_ISO_Left_Tab
 			|| key_event->keyval == GDK_KEY_KP_Tab)
 	{
-		const Keyboard::Direction dir =
-				((key_event->state & GDK_SHIFT_MASK)
-				 || key_event->keyval == GDK_KEY_ISO_Left_Tab)
-					? Keyboard::Direction::Backward
-					: Keyboard::Direction::Forward;
-		const Keyboard::Zone here = current_zone();
-		const Keyboard::Zone next = Keyboard::next_zone(
-				current_visibility_mask(),
-				current_menu_state(),
-				here,
-				dir);
-		if (next != here)
+		if (key_event->state & GDK_CONTROL_MASK)
 		{
-			grab_focus_in_zone(next);
+			// Ctrl+Tab forward, Ctrl+Shift+Tab (or ISO_Left_Tab) backward.
+			const Keyboard::Direction dir =
+					((key_event->state & GDK_SHIFT_MASK)
+					 || key_event->keyval == GDK_KEY_ISO_Left_Tab)
+						? Keyboard::Direction::Backward
+						: Keyboard::Direction::Forward;
+			const Keyboard::Zone here = current_zone();
+			const Keyboard::Zone next = Keyboard::next_zone(
+					current_visibility_mask(),
+					current_menu_state(),
+					here,
+					dir);
+			if (next != here)
+			{
+				grab_focus_in_zone(next);
+			}
+			return GDK_EVENT_STOP;
+		}
+
+		// Bare Tab/Shift+Tab toggles the mode (or is inert when Places is
+		// unavailable). FR-006: Tab never silently falls back to area
+		// cycling, so the Inert arm consumes the event and changes nothing.
+		switch (Keyboard::tab_action(m_settings->places_enabled))
+		{
+		case Keyboard::TabAction::ToggleMode:
+			// switch_mode resets the new view to its default selection and
+			// clears the query; the Tab path then lands focus on Results so
+			// the user sees the new view's default item (FR-003).
+			switch_mode(!m_places_active);
+			grab_focus_in_zone(Keyboard::Zone::Results);
+			break;
+		case Keyboard::TabAction::Inert:
+			break;
 		}
 		return GDK_EVENT_STOP;
 	}

--- a/panel-plugin/places/favourites-section.cpp
+++ b/panel-plugin/places/favourites-section.cpp
@@ -185,6 +185,9 @@ void FavouritesSection::remove_favourite(const char* uri)
  */
 std::vector<PlacesItem*> FavouritesSection::get_items(int max)
 {
+	// Like the history section, build fresh PlacesItem objects every call so
+	// each favourite's exists() — and its muted markup/"missing" tooltip — is
+	// re-evaluated at each rebuild (FR-007); no filesystem watch is added.
 	clear_items();
 
 	std::vector<std::string> uris;

--- a/panel-plugin/places/history-section.cpp
+++ b/panel-plugin/places/history-section.cpp
@@ -58,6 +58,10 @@ void HistorySection::clear_items()
  */
 std::vector<PlacesItem*> HistorySection::get_items(int max)
 {
+	// Rebuild fresh PlacesItem objects on every call (clear_items() + new
+	// below), so each item's exists() — and therefore its muted markup and
+	// "missing" tooltip — is re-evaluated against the live filesystem at every
+	// list rebuild (FR-007). No filesystem watch is involved.
 	clear_items();
 	if (!m_manager)
 	{

--- a/panel-plugin/places/places-item.cpp
+++ b/panel-plugin/places/places-item.cpp
@@ -78,7 +78,35 @@ PlacesItem::PlacesItem(GFile* file, bool is_favourite) :
 		g_free(basename);
 	}
 
-	set_tooltip(path ? path : m_uri.c_str());
+	const char* label = get_text() ? get_text() : "";
+	if (m_exists)
+	{
+		// Available: keep today's plain label and the path/URI tooltip.
+		m_display_markup = label;
+		set_tooltip(path ? path : m_uri.c_str());
+	}
+	else
+	{
+		// Missing: mute the label and flag the target as gone.
+		// NOTE: escape the display name before wrapping it — the shared
+		// tree-view renders COLUMN_TEXT as Pango markup, so an unescaped
+		// "&" or "<" in a file name would corrupt the row.
+		gchar* escaped = g_markup_escape_text(label, -1);
+		// NOTE: dim via alpha over the inherited theme foreground rather than
+		// a fixed colour, so the muted text stays legible on light and dark
+		// themes (no hard-coded colour).
+		gchar* markup = g_strdup_printf("<span alpha=\"55%%\">%s</span>",
+				escaped ? escaped : "");
+		m_display_markup = markup ? markup : "";
+		g_free(markup);
+		g_free(escaped);
+
+		// Tooltip names the target and states it is missing; set_tooltip()
+		// escapes the text for markup, so pass it raw.
+		gchar* tip = g_strdup_printf(_("%s (missing)"), path ? path : m_uri.c_str());
+		set_tooltip(tip);
+		g_free(tip);
+	}
 
 	gchar* folded = g_utf8_casefold(get_text(), -1);
 	m_casefolded_name = folded ? folded : "";

--- a/panel-plugin/places/places-item.h
+++ b/panel-plugin/places/places-item.h
@@ -36,6 +36,16 @@ public:
 	GFile* get_file() const     { return m_file; }
 	const char* get_uri() const { return m_uri.c_str(); }
 	bool exists() const         { return m_exists; }
+
+	/* get_display_markup:
+	 *
+	 * Returns: the label to feed into the markup-rendered list column. For a
+	 * missing item this is muted Pango markup (theme foreground at reduced
+	 * alpha, no hard-coded colour); for an available item it is the plain
+	 * display text, identical to get_text(). The returned string is owned by
+	 * the item and stays valid for its lifetime.
+	 */
+	const char* get_display_markup() const { return m_display_markup.c_str(); }
 	bool is_directory() const   { return m_is_directory; }
 	bool is_favourite() const   { return m_is_favourite; }
 	gint64 get_accessed() const { return m_accessed; }
@@ -68,6 +78,7 @@ public:
 private:
 	GFile* m_file;
 	std::string m_uri;
+	std::string m_display_markup;
 	std::string m_casefolded_name;
 	gint64 m_accessed;
 	bool m_exists;

--- a/panel-plugin/places/places-page.cpp
+++ b/panel-plugin/places/places-page.cpp
@@ -284,12 +284,14 @@ void PlacesPage::on_home_search_result(PlacesItem* item)
 	{
 		return;
 	}
-	// Take ownership and append shallow-first into the model.
+	// Take ownership and append shallow-first into the model. Use the same
+	// availability-driven markup/tooltip feed as rebuild_model() so missing
+	// home-search results render muted consistently.
 	m_home_search_items.push_back(item);
 	gtk_list_store_insert_with_values(
 			m_model, nullptr, G_MAXINT,
 			LauncherView::COLUMN_ICON, item->get_icon(),
-			LauncherView::COLUMN_TEXT, item->get_text(),
+			LauncherView::COLUMN_TEXT, item->get_display_markup(),
 			LauncherView::COLUMN_TOOLTIP, item->get_tooltip(),
 			LauncherView::COLUMN_LAUNCHER, static_cast<Element*>(item),
 			-1);
@@ -339,10 +341,12 @@ void PlacesPage::rebuild_model()
 		{
 			continue;
 		}
+		// Feed the availability-driven markup so missing items render muted;
+		// get_tooltip() already carries the "missing" cue for those items.
 		gtk_list_store_insert_with_values(
 				m_model, nullptr, G_MAXINT,
 				LauncherView::COLUMN_ICON, item->get_icon(),
-				LauncherView::COLUMN_TEXT, item->get_text(),
+				LauncherView::COLUMN_TEXT, item->get_display_markup(),
 				LauncherView::COLUMN_TOOLTIP, item->get_tooltip(),
 				LauncherView::COLUMN_LAUNCHER, static_cast<Element*>(item),
 				-1);
@@ -366,6 +370,13 @@ void PlacesPage::on_row_activated(GtkTreePath* path)
 			LauncherView::COLUMN_LAUNCHER, &element, -1);
 	auto* item = dynamic_cast<PlacesItem*>(element);
 	if (!item)
+	{
+		return;
+	}
+	// Missing target: primary activation is inert — do not close the menu,
+	// do not launch, and show no error. Recovery is offered through the
+	// context menu ("Open Containing Folder").
+	if (!item->exists())
 	{
 		return;
 	}
@@ -430,6 +441,10 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 			m_window->hide();
 			item->open(s);
 		});
+	// "Open" stays present but insensitive for a missing target, matching the
+	// inert primary activation; "Open Containing Folder" below remains enabled
+	// so a renamed file can still be located.
+	gtk_widget_set_sensitive(mi, item->exists());
 	append(mi);
 
 	const bool meow_only = m_favourites
@@ -438,6 +453,9 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 	{
 		if (item->is_favourite())
 		{
+			// Left enabled for missing favourites (not gated on exists()) so a
+			// stale favourite can always be removed even though "Open" above is
+			// greyed — this is the greyed-out-favourite behaviour from 005.
 			mi = whiskermenu_image_menu_item_new("list-remove", _("Remove from Favourites"));
 			connect(mi, "activate",
 				[this, item](GtkMenuItem*)
@@ -460,6 +478,10 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 		}
 	}
 
+	// Offered for both recent and favourite items, and intentionally left
+	// enabled even when the target is missing so a renamed file can be located
+	// from its parent folder. PlacesItem::open_containing() fails silently (no
+	// dialog) when the parent is also gone.
 	mi = whiskermenu_image_menu_item_new("folder-open", _("Open Containing Folder"));
 	connect(mi, "activate",
 		[this, item](GtkMenuItem*)

--- a/po/xfce4-meowmenu-plugin.pot
+++ b/po/xfce4-meowmenu-plugin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xfce4-meowmenu-plugin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 12:08+0200\n"
+"POT-Creation-Date: 2026-05-31 09:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,1099 +17,1155 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: panel-plugin/applications-page.cpp:35 panel-plugin/category.cpp:52
-#: panel-plugin/settings-dialog.cpp:2745
+#: panel-plugin/launcher/applications-page.cpp:35
+#: panel-plugin/launcher/category.cpp:52
+#: panel-plugin/ui/properties/sidebar.cpp:217
 msgid "All Applications"
 msgstr ""
 
-#: panel-plugin/command-edit.cpp:65
+#: panel-plugin/ui/command-edit.cpp:65
 msgid "Browse the file system to choose a custom command."
 msgstr ""
 
-#: panel-plugin/command-edit.cpp:75
+#: panel-plugin/ui/command-edit.cpp:75
 msgid "Select Command"
 msgstr ""
 
-#: panel-plugin/command-edit.cpp:78 panel-plugin/settings-dialog.cpp:276
-#: panel-plugin/settings-dialog.cpp:449 panel-plugin/settings-dialog.cpp:916
-#: panel-plugin/settings-dialog.cpp:972 panel-plugin/settings-dialog.cpp:1062
-#: panel-plugin/settings-dialog.cpp:1098 panel-plugin/settings-dialog.cpp:1132
-#: panel-plugin/settings-dialog.cpp:1146 panel-plugin/settings-dialog.cpp:2070
+#: panel-plugin/ui/command-edit.cpp:78 panel-plugin/settings-dialog.cpp:187
+#: panel-plugin/settings-dialog.cpp:360
+#: panel-plugin/ui/properties/general.cpp:127
+#: panel-plugin/ui/properties/general.cpp:183
+#: panel-plugin/ui/properties/general.cpp:273
+#: panel-plugin/ui/properties/general.cpp:309
+#: panel-plugin/ui/properties/general.cpp:343
+#: panel-plugin/ui/properties/general.cpp:357
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:149
 msgid "_Cancel"
 msgstr ""
 
-#: panel-plugin/command-edit.cpp:79 panel-plugin/settings-dialog.cpp:277
-#: panel-plugin/settings-dialog.cpp:450
+#: panel-plugin/ui/command-edit.cpp:79 panel-plugin/settings-dialog.cpp:188
+#: panel-plugin/settings-dialog.cpp:361
 msgid "_OK"
 msgstr ""
 
-#: panel-plugin/element.cpp:98
+#: panel-plugin/launcher/element.cpp:98
 #, c-format
 msgid "Failed to execute command \"%s\"."
 msgstr ""
 
-#: panel-plugin/favorites-page.cpp:37 panel-plugin/settings-dialog.cpp:2736
+#: panel-plugin/launcher/favorites-page.cpp:37
+#: panel-plugin/ui/properties/sidebar.cpp:208
 msgid "Favorites"
 msgstr ""
 
-#: panel-plugin/favorites-page.cpp:152
+#: panel-plugin/launcher/favorites-page.cpp:152
 msgid "Move Up"
 msgstr ""
 
-#: panel-plugin/favorites-page.cpp:164
+#: panel-plugin/launcher/favorites-page.cpp:164
 msgid "Move Down"
 msgstr ""
 
-#: panel-plugin/favorites-page.cpp:180
+#: panel-plugin/launcher/favorites-page.cpp:180
 msgid "Sort Alphabetically A-Z"
 msgstr ""
 
-#: panel-plugin/favorites-page.cpp:188
+#: panel-plugin/launcher/favorites-page.cpp:188
 msgid "Sort Alphabetically Z-A"
 msgstr ""
 
-#: panel-plugin/favourites-section.cpp:44
+#: panel-plugin/places/favourites-section.cpp:44
 msgid "Favourites"
 msgstr ""
 
-#: panel-plugin/history-section.cpp:37
+#: panel-plugin/places/history-section.cpp:37
 msgid "History"
 msgstr ""
 
-#: panel-plugin/home-section.cpp:60
+#: panel-plugin/places/home-section.cpp:60
 msgid "Home"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:61
+#: panel-plugin/ui/icon-size.cpp:61
 msgid "None"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:62
+#: panel-plugin/ui/icon-size.cpp:62
 msgid "Very Small"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:63
+#: panel-plugin/ui/icon-size.cpp:63
 msgid "Smaller"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:64
+#: panel-plugin/ui/icon-size.cpp:64
 msgid "Small"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:65
+#: panel-plugin/ui/icon-size.cpp:65
 msgid "Normal"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:66
+#: panel-plugin/ui/icon-size.cpp:66
 msgid "Large"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:67
+#: panel-plugin/ui/icon-size.cpp:67
 msgid "Larger"
 msgstr ""
 
-#: panel-plugin/icon-size.cpp:68
+#: panel-plugin/ui/icon-size.cpp:68
 msgid "Very Large"
 msgstr ""
 
 #. I18N: the first %s will be replaced with desktop file path, the second with Hidden=true
-#: panel-plugin/launcher.cpp:207
+#: panel-plugin/launcher/launcher.cpp:207
 #, c-format
 msgid ""
 "To unhide it you have to manually remove the file \"%s\" or open the file "
 "and remove the line \"%s\"."
 msgstr ""
 
-#: panel-plugin/launcher.cpp:211 panel-plugin/page.cpp:524
+#: panel-plugin/launcher/launcher.cpp:211 panel-plugin/launcher/page.cpp:555
 msgid "Hide Application"
 msgstr ""
 
-#: panel-plugin/launcher.cpp:212
+#: panel-plugin/launcher/launcher.cpp:212
 #, c-format
 msgid "Are you sure you want to hide \"%s\"?"
 msgstr ""
 
-#: panel-plugin/page.cpp:453
+#: panel-plugin/launcher/page.cpp:484
 msgid "Add to Favorites"
 msgstr ""
 
-#: panel-plugin/page.cpp:464
+#: panel-plugin/launcher/page.cpp:495
 msgid "Remove from Favorites"
 msgstr ""
 
-#: panel-plugin/page.cpp:474
+#: panel-plugin/launcher/page.cpp:505
 msgid "Add to Desktop"
 msgstr ""
 
-#: panel-plugin/page.cpp:482
+#: panel-plugin/launcher/page.cpp:513
 msgid "Add to Panel"
 msgstr ""
 
-#: panel-plugin/page.cpp:492
+#: panel-plugin/launcher/page.cpp:523
 msgid "Add to Autostart"
 msgstr ""
 
-#: panel-plugin/page.cpp:503
+#: panel-plugin/launcher/page.cpp:534
 msgid "Remove from Autostart"
 msgstr ""
 
-#: panel-plugin/page.cpp:516
+#: panel-plugin/launcher/page.cpp:547
 msgid "Edit Application..."
 msgstr ""
 
-#: panel-plugin/page.cpp:587
+#: panel-plugin/launcher/page.cpp:618
 msgid "Unable to add launcher to desktop."
 msgstr ""
 
-#: panel-plugin/page.cpp:627 panel-plugin/page.cpp:640
+#: panel-plugin/launcher/page.cpp:658 panel-plugin/launcher/page.cpp:671
 msgid "Unable to add launcher to panel."
 msgstr ""
 
-#: panel-plugin/page.cpp:664
+#: panel-plugin/launcher/page.cpp:695
 msgid "Unable to edit launcher."
 msgstr ""
 
-#: panel-plugin/places-item.cpp:149
+#. Tooltip names the target and states it is missing; set_tooltip()
+#. escapes the text for markup, so pass it raw.
+#: panel-plugin/places/places-item.cpp:106
+#, c-format
+msgid "%s (missing)"
+msgstr ""
+
+#: panel-plugin/places/places-item.cpp:177
 #, c-format
 msgid "Unable to open \"%s\"."
 msgstr ""
 
-#: panel-plugin/places-item.cpp:273
+#: panel-plugin/places/places-item.cpp:301
 msgid "Unable to add desktop link."
 msgstr ""
 
-#: panel-plugin/places-page.cpp:64
+#: panel-plugin/places/places-page.cpp:64
 msgid "No items to show."
 msgstr ""
 
-#: panel-plugin/places-page.cpp:405
+#: panel-plugin/places/places-page.cpp:436
 msgid "_Open"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:421
+#. Left enabled for missing favourites (not gated on exists()) so a
+#. stale favourite can always be removed even though "Open" above is
+#. greyed — this is the greyed-out-favourite behaviour from 005.
+#: panel-plugin/places/places-page.cpp:459
 msgid "Remove from Favourites"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:432
+#: panel-plugin/places/places-page.cpp:470
 msgid "Add to Favourites"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:443
+#. Offered for both recent and favourite items, and intentionally left
+#. enabled even when the target is missing so a renamed file can be located
+#. from its parent folder. PlacesItem::open_containing() fails silently (no
+#. dialog) when the parent is also gone.
+#: panel-plugin/places/places-page.cpp:485
 msgid "Open Containing Folder"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:453
+#: panel-plugin/places/places-page.cpp:495
 msgid "Copy Path"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:460
+#: panel-plugin/places/places-page.cpp:502
 msgid "Open in Terminal"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:472
+#: panel-plugin/places/places-page.cpp:514
 msgid "Open With…"
 msgstr ""
 
-#: panel-plugin/places-page.cpp:477
+#: panel-plugin/places/places-page.cpp:519
 msgid "Add Desktop Link"
 msgstr ""
 
-#: panel-plugin/plugin.cpp:435
+#: panel-plugin/core/plugin.cpp:446
 msgid ""
 "News file not found.\n"
 "Run 'meson install' to make it available."
 msgstr ""
 
-#: panel-plugin/plugin.cpp:441 panel-plugin/plugin.cpp:510
+#: panel-plugin/core/plugin.cpp:452 panel-plugin/core/plugin.cpp:521
 msgid "What's New"
 msgstr ""
 
-#: panel-plugin/plugin.cpp:444
+#: panel-plugin/core/plugin.cpp:455
 msgid "Close"
 msgstr ""
 
-#: panel-plugin/plugin.cpp:502
+#: panel-plugin/core/plugin.cpp:513
 msgid "Alternate launcher for XFCE4"
 msgstr ""
 
-#: panel-plugin/plugin.cpp:508
+#: panel-plugin/core/plugin.cpp:519
 msgid "Based on Whisker Menu"
 msgstr ""
 
-#: panel-plugin/recent-page.cpp:37 panel-plugin/settings-dialog.cpp:2740
+#. NOTE: fallback if initialize_file_presets() was not called or all files missing.
+#: panel-plugin/presets/preset.cpp:61 panel-plugin/settings-dialog.cpp:608
+msgid "Classic"
+msgstr ""
+
+#: panel-plugin/presets/preset.cpp:62
+msgid ""
+"Traditional Whisker Menu layout. Compact window, sidebar on the right, apps "
+"as a list."
+msgstr ""
+
+#: panel-plugin/presets/preset.cpp:89 panel-plugin/settings-dialog.cpp:609
+msgid "Modern"
+msgstr ""
+
+#: panel-plugin/presets/preset.cpp:90
+msgid ""
+"Contemporary layout with rounded corners, categories on the left, and hover-"
+"to-switch enabled."
+msgstr ""
+
+#: panel-plugin/presets/preset.cpp:118 panel-plugin/settings-dialog.cpp:610
+msgid "Full Screen"
+msgstr ""
+
+#: panel-plugin/presets/preset.cpp:119
+msgid ""
+"Launcher fills the whole screen with a centered grid and categories on the "
+"left."
+msgstr ""
+
+#: panel-plugin/launcher/recent-page.cpp:37
+#: panel-plugin/ui/properties/sidebar.cpp:212
 msgid "Recently Used"
 msgstr ""
 
-#: panel-plugin/recent-page.cpp:147
+#: panel-plugin/launcher/recent-page.cpp:147
 msgid "Clear Recently Used"
 msgstr ""
 
-#: panel-plugin/run-action.cpp:65
+#: panel-plugin/search/run-action.cpp:65
 #, c-format
 msgid "Run %s"
 msgstr ""
 
-#: panel-plugin/search-action.cpp:262
+#: panel-plugin/search/search-action.cpp:262
 msgid "Search Action"
 msgstr ""
 
-#: panel-plugin/search-page.cpp:85
+#: panel-plugin/search/search-page.cpp:85
 msgid "No applications found"
 msgstr ""
 
 #. Create dialog window
-#: panel-plugin/settings-dialog.cpp:157 panel-plugin/whiskermenu.desktop.in:4
+#: panel-plugin/settings-dialog.cpp:68 panel-plugin/meowmenu.desktop.in:4
 msgid "Meow Menu"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:160
+#: panel-plugin/settings-dialog.cpp:71
 msgid "_Help"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:161
+#: panel-plugin/settings-dialog.cpp:72
 msgid "_Close"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:188
+#: panel-plugin/settings-dialog.cpp:99
 msgid "General"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:189
+#: panel-plugin/settings-dialog.cpp:100
 msgid "User / Session"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:190
+#: panel-plugin/settings-dialog.cpp:101
 msgid "Search Bar"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:191
+#: panel-plugin/settings-dialog.cpp:102
 msgid "Results View"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:192
+#: panel-plugin/settings-dialog.cpp:103
 msgid "Sidebar"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:193 panel-plugin/window.cpp:413
+#: panel-plugin/settings-dialog.cpp:104 panel-plugin/core/window.cpp:527
 msgid "Places"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:271 panel-plugin/settings-dialog.cpp:273
+#: panel-plugin/settings-dialog.cpp:182 panel-plugin/settings-dialog.cpp:184
 msgid "Select an Icon"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:370 panel-plugin/settings-dialog.cpp:1010
-#: panel-plugin/settings-dialog.cpp:1025
+#: panel-plugin/settings-dialog.cpp:281
+#: panel-plugin/ui/properties/general.cpp:221
+#: panel-plugin/ui/properties/general.cpp:236
 msgid "_Delete"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:371
+#: panel-plugin/settings-dialog.cpp:282
 msgid "The action will be deleted permanently."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:372
+#: panel-plugin/settings-dialog.cpp:283
 #, c-format
 msgid "Remove action \"%s\"?"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:446
+#: panel-plugin/settings-dialog.cpp:357
 msgid "Edit search action"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:461
+#: panel-plugin/settings-dialog.cpp:372
 msgid "Nam_e:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:471
+#: panel-plugin/settings-dialog.cpp:382
 msgid "_Pattern:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:481
+#: panel-plugin/settings-dialog.cpp:392
 msgid "C_ommand:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:491
+#: panel-plugin/settings-dialog.cpp:402
 msgid "Is _regular expression"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:535
+#: panel-plugin/settings-dialog.cpp:446
 #, c-format
 msgid "Unable to open the following url: %s"
 msgstr ""
 
-#. NOTE: fallback if initialize_file_presets() was not called or all files missing.
-#: panel-plugin/settings-dialog.cpp:697
-msgid "Classic"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:698
-msgid "Modern"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:699
-msgid "Full Screen"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:800
+#: panel-plugin/settings-dialog.cpp:711
 msgid "Render profile, search and session on a single horizontal row."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:802
+#: panel-plugin/settings-dialog.cpp:713
 msgid "This option requires the FullScreen layout."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:804
+#: panel-plugin/settings-dialog.cpp:715
 msgid ""
 "This option requires profile, search and session to be on the same end (all "
 "top or all bottom)."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:857
+#: panel-plugin/ui/properties/general.cpp:68
 msgid "Preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:860
+#: panel-plugin/ui/properties/general.cpp:71
 msgid "_Preset:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:875
+#: panel-plugin/ui/properties/general.cpp:86
 msgid "● Customized"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:885
+#: panel-plugin/ui/properties/general.cpp:96
 msgid "_Reset preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:896 panel-plugin/settings-dialog.cpp:1205
+#: panel-plugin/ui/properties/general.cpp:107
+#: panel-plugin/ui/properties/general.cpp:416
 msgid "_Reset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:897
+#: panel-plugin/ui/properties/general.cpp:108
 msgid "All customizations will be discarded and the preset values restored."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:898
+#: panel-plugin/ui/properties/general.cpp:109
 #, c-format
 msgid "Reset preset \"%s\"?"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:907
+#: panel-plugin/ui/properties/general.cpp:118
 msgid "_Save as new…"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:913
+#: panel-plugin/ui/properties/general.cpp:124
 msgid "Save as new preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:917
+#: panel-plugin/ui/properties/general.cpp:128
 msgid "_Save"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:926 panel-plugin/settings-dialog.cpp:982
-#: panel-plugin/settings-dialog.cpp:1154
+#: panel-plugin/ui/properties/general.cpp:137
+#: panel-plugin/ui/properties/general.cpp:193
+#: panel-plugin/ui/properties/general.cpp:365
 msgid "_Name:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:942 panel-plugin/settings-dialog.cpp:999
+#: panel-plugin/ui/properties/general.cpp:153
+#: panel-plugin/ui/properties/general.cpp:210
 msgid "A preset with that name already exists or the name is empty."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:943
+#: panel-plugin/ui/properties/general.cpp:154
 msgid "Could not save preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:955
+#: panel-plugin/ui/properties/general.cpp:166
 msgid "Re_name…"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:969
+#: panel-plugin/ui/properties/general.cpp:180
 msgid "Rename preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:973
+#: panel-plugin/ui/properties/general.cpp:184
 msgid "_Rename"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1000
+#: panel-plugin/ui/properties/general.cpp:211
 msgid "Could not rename preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1026
+#: panel-plugin/ui/properties/general.cpp:237
 msgid "This preset will be permanently removed."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1027
+#: panel-plugin/ui/properties/general.cpp:238
 #, c-format
 msgid "Delete preset \"%s\"?"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1044
+#: panel-plugin/ui/properties/general.cpp:255
 msgid "E_xport…"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1059
+#: panel-plugin/ui/properties/general.cpp:270
 msgid "Export preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1062
+#: panel-plugin/ui/properties/general.cpp:273
 msgid "_Export"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1068 panel-plugin/settings-dialog.cpp:1101
+#: panel-plugin/ui/properties/general.cpp:279
+#: panel-plugin/ui/properties/general.cpp:312
 msgid "MeowMenu preset (*.meowpreset)"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1080
+#: panel-plugin/ui/properties/general.cpp:291
 msgid "Could not export preset."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1088
+#: panel-plugin/ui/properties/general.cpp:299
 msgid "_Import…"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1095
+#: panel-plugin/ui/properties/general.cpp:306
 msgid "Import preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1098 panel-plugin/settings-dialog.cpp:1147
+#: panel-plugin/ui/properties/general.cpp:309
+#: panel-plugin/ui/properties/general.cpp:358
 msgid "_Import"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1127
+#: panel-plugin/ui/properties/general.cpp:338
 #, c-format
 msgid "A preset named \"%s\" already exists. What would you like to do?"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1130
+#: panel-plugin/ui/properties/general.cpp:341
 msgid "_Overwrite"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1131
+#: panel-plugin/ui/properties/general.cpp:342
 msgid "Re_name"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1143
+#: panel-plugin/ui/properties/general.cpp:354
 msgid "Rename imported preset"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1189
+#: panel-plugin/ui/properties/general.cpp:400
 msgid "Could not import preset"
 msgstr ""
 
 #. Reset to defaults — full channel reset, kept here as the most logical
 #. action button for the Preset hub.
-#: panel-plugin/settings-dialog.cpp:1196
+#: panel-plugin/ui/properties/general.cpp:407
 msgid "Reset to _defaults"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1206
+#: panel-plugin/ui/properties/general.cpp:417
 msgid ""
 "All settings will be reset to defaults and the Modern preset will be applied."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1207
+#: panel-plugin/ui/properties/general.cpp:418
 msgid "Reset all settings to defaults?"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1280
+#: panel-plugin/ui/properties/general.cpp:491
 msgid ""
 "FullScreen mode requires gtk-layer-shell on Wayland. The menu will open as a "
 "regular window instead."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1302
+#: panel-plugin/ui/properties/general.cpp:513
 msgid "Panel plugin"
 msgstr ""
 
 #. Show panel button title
-#: panel-plugin/settings-dialog.cpp:1308
+#: panel-plugin/ui/properties/general.cpp:519
 msgid "Show panel button _title"
 msgstr ""
 
 #. Title entry
-#: panel-plugin/settings-dialog.cpp:1315
+#: panel-plugin/ui/properties/general.cpp:526
 msgid "T_itle:"
 msgstr ""
 
 #. Show panel button icon
-#: panel-plugin/settings-dialog.cpp:1352
+#: panel-plugin/ui/properties/general.cpp:563
 msgid "Show panel button _icon"
 msgstr ""
 
 #. Icon picker
-#: panel-plugin/settings-dialog.cpp:1359
+#: panel-plugin/ui/properties/general.cpp:570
 msgid "Ic_on:"
 msgstr ""
 
 #. Single-row panel layout
-#: panel-plugin/settings-dialog.cpp:1396
+#: panel-plugin/ui/properties/general.cpp:607
 msgid "Use a single panel _row"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1420
+#: panel-plugin/ui/properties/general.cpp:631
 msgid "General menu settings"
 msgstr ""
 
 #. Layout mode
-#: panel-plugin/settings-dialog.cpp:1426
+#: panel-plugin/ui/properties/general.cpp:637
 msgid "_Layout mode:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1431
+#: panel-plugin/ui/properties/general.cpp:642
 msgid "Docked"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1432
+#: panel-plugin/ui/properties/general.cpp:643
 msgid "FullScreen"
 msgstr ""
 
 #. Panel gap
-#: panel-plugin/settings-dialog.cpp:1459
+#: panel-plugin/ui/properties/general.cpp:670
 msgid "_Panel gap:"
 msgstr ""
 
 #. Menu width (enable-when-docked)
-#: panel-plugin/settings-dialog.cpp:1481
+#: panel-plugin/ui/properties/general.cpp:692
 msgid "Menu _width:"
 msgstr ""
 
 #. Menu height (enable-when-docked)
-#: panel-plugin/settings-dialog.cpp:1501
+#: panel-plugin/ui/properties/general.cpp:712
 msgid "Menu _height:"
 msgstr ""
 
 #. Corner radius
-#: panel-plugin/settings-dialog.cpp:1521
+#: panel-plugin/ui/properties/general.cpp:732
 msgid "_Corner radius:"
 msgstr ""
 
 #. Full-screen opacity (enable-when-fullscreen) — schema v2 key.
-#: panel-plugin/settings-dialog.cpp:1543
+#: panel-plugin/ui/properties/general.cpp:754
 msgid "F_ull-screen opacity:"
 msgstr ""
 
 #. Stay visible when focus is lost (FR-013: lives only in General).
-#: panel-plugin/settings-dialog.cpp:1565
+#: panel-plugin/ui/properties/general.cpp:776
 msgid "Stay _visible when focus is lost"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1613
-msgid "Profile"
+#: panel-plugin/ui/properties/places.cpp:53
+msgid "Places mode"
 msgstr ""
 
-#. Profile position
-#: panel-plugin/settings-dialog.cpp:1617
-msgid "_Position:"
+#: panel-plugin/ui/properties/places.cpp:56
+msgid "Enable _Places"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1622 panel-plugin/settings-dialog.cpp:1815
-msgid "Top"
+#: panel-plugin/ui/properties/places.cpp:68
+msgid "Sections"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1623 panel-plugin/settings-dialog.cpp:1816
-msgid "Bottom"
+#: panel-plugin/ui/properties/places.cpp:74
+msgid "Enable _History section"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1624 panel-plugin/settings-dialog.cpp:1694
-msgid "Bottom Right"
+#: panel-plugin/ui/properties/places.cpp:84
+msgid "Enable _Favourites section"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1625 panel-plugin/settings-dialog.cpp:1695
-#: panel-plugin/settings-dialog.cpp:2673
-msgid "Hidden"
+#: panel-plugin/ui/properties/places.cpp:93
+msgid "Favourite _sync:"
 msgstr ""
 
-#. Avatar shape (sub-enabled when profile-position != hidden).
-#: panel-plugin/settings-dialog.cpp:1635
-msgid "Avatar _shape:"
+#: panel-plugin/ui/properties/places.cpp:96
+msgid "MeowMenu only"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1640
-msgid "Round Picture"
+#: panel-plugin/ui/properties/places.cpp:97
+msgid "Thunar bookmarks (read-only)"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1641
-msgid "Square Picture"
+#: panel-plugin/ui/properties/places.cpp:105
+msgid "Maximum places _items:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1685
-msgid "Commands"
+#: panel-plugin/ui/properties/places.cpp:118
+#: panel-plugin/ui/properties/sidebar.cpp:178
+msgid "Behaviour"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1688
-msgid "_Commands position:"
+#: panel-plugin/ui/properties/places.cpp:122
+msgid "_Remember last selected mode"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1693
-msgid "Top Right"
+#: panel-plugin/ui/properties/places.cpp:127
+msgid "Show item _metadata"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1720
-msgid "Place profile, search and session on a single _line"
+#: panel-plugin/ui/properties/results-view.cpp:62
+msgid "View"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1749
-msgid "Show c_onfirmation dialog"
+#: panel-plugin/ui/properties/results-view.cpp:71
+msgid "Show as _icons"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1764
-msgid "Session commands"
+#: panel-plugin/ui/properties/results-view.cpp:84
+msgid "Show as lis_t"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1807 panel-plugin/settings-dialog.cpp:2663
+#: panel-plugin/ui/properties/results-view.cpp:97
+msgid "Show as t_ree"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:123
+msgid "Layout"
+msgstr ""
+
+#. Grid density (icons-only sub-enable)
+#: panel-plugin/ui/properties/results-view.cpp:129
+msgid "Grid _density:"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:134
+#: panel-plugin/ui/properties/search-bar.cpp:181
+msgid "Low"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:135
+#: panel-plugin/ui/properties/search-bar.cpp:182
+msgid "Medium"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:136
+#: panel-plugin/ui/properties/search-bar.cpp:183
+msgid "High"
+msgstr ""
+
+#. Application icon size (icons-only sub-enable)
+#: panel-plugin/ui/properties/results-view.cpp:158
+msgid "Application icon si_ze:"
+msgstr ""
+
+#. NOTE: launcher_show_name stores "show the real (non-generic) name"; the
+#. checkbox is therefore inverted — checked means "Show generic" (false).
+#: panel-plugin/ui/properties/results-view.cpp:182
+msgid "Show generic application _names"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:194
+msgid "Show application too_ltips"
+msgstr ""
+
+#. Show descriptions — list-only sub-enable.
+#: panel-plugin/ui/properties/results-view.cpp:206
+msgid "Show application _descriptions"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:271
+msgid "Opacity"
+msgstr ""
+
+#: panel-plugin/ui/properties/results-view.cpp:274
+msgid "App _box opacity:"
+msgstr ""
+
+#: panel-plugin/ui/properties/search-bar.cpp:58
+#: panel-plugin/ui/properties/sidebar.cpp:135
 msgid "Position"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1810
+#: panel-plugin/ui/properties/search-bar.cpp:61
 msgid "_Search bar position:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1842
+#: panel-plugin/ui/properties/search-bar.cpp:66
+#: panel-plugin/ui/properties/user-session.cpp:68
+msgid "Top"
+msgstr ""
+
+#: panel-plugin/ui/properties/search-bar.cpp:67
+#: panel-plugin/ui/properties/user-session.cpp:69
+msgid "Bottom"
+msgstr ""
+
+#: panel-plugin/ui/properties/search-bar.cpp:93
 msgid "_Fuzzy matching:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1865
+#: panel-plugin/ui/properties/search-bar.cpp:116
 msgid "Max _errors (0=auto):"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1886
+#: panel-plugin/ui/properties/search-bar.cpp:137
 msgid "Fuzzy Search"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1887
+#: panel-plugin/ui/properties/search-bar.cpp:138
 msgid ""
 "Finds apps even when you mistype a word.\n"
 "Example: \"firfox\" still finds Firefox.\n"
 "Max errors 0 = automatic (1 for short queries, 2 for longer ones)."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1900
+#: panel-plugin/ui/properties/search-bar.cpp:151
 msgid "_Boost favorites:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1923
+#: panel-plugin/ui/properties/search-bar.cpp:174
 msgid "Boost _level:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1930 panel-plugin/settings-dialog.cpp:2394
-msgid "Low"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:1931 panel-plugin/settings-dialog.cpp:2395
-msgid "Medium"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:1932 panel-plugin/settings-dialog.cpp:2396
-msgid "High"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:1948
+#: panel-plugin/ui/properties/search-bar.cpp:199
 msgid "Recency _weight (%):"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1968
+#: panel-plugin/ui/properties/search-bar.cpp:219
 msgid "Usage Boost"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:1969
+#: panel-plugin/ui/properties/search-bar.cpp:220
 msgid ""
 "Promotes apps you use frequently or marked as favorites.\n"
 "Recency weight controls the balance between how recently vs.\n"
 "how often you launched an app."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2011 panel-plugin/settings-dialog.cpp:2087
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:92
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:166
 msgid "Application"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2018
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:99
 msgid "Aliases (comma-separated)"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2057 panel-plugin/settings-dialog.cpp:2071
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:137
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:150
 msgid "_Add"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2058
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:138
 msgid "_Remove"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2067
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:146
 msgid "Choose Application"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2159
+#: panel-plugin/ui/properties/search-bar-aliases.cpp:237
 msgid "Aliases"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2187
+#: panel-plugin/ui/properties/search-bar-actions.cpp:84
 msgid "Name"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2193
+#: panel-plugin/ui/properties/search-bar-actions.cpp:90
 msgid "Pattern"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2213
+#: panel-plugin/ui/properties/search-bar-actions.cpp:110
 msgid "Add action"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2220
+#: panel-plugin/ui/properties/search-bar-actions.cpp:117
 msgid "Remove selected action"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2229
+#: panel-plugin/ui/properties/search-bar-actions.cpp:127
 msgid "Edit selected action…"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2286
+#: panel-plugin/ui/properties/search-bar-actions.cpp:184
 msgid "Search actions"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2322
-msgid "View"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2331
-msgid "Show as _icons"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2344
-msgid "Show as lis_t"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2357
-msgid "Show as t_ree"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2383
-msgid "Layout"
-msgstr ""
-
-#. Grid density (icons-only sub-enable)
-#: panel-plugin/settings-dialog.cpp:2389
-msgid "Grid _density:"
-msgstr ""
-
-#. Application icon size (icons-only sub-enable)
-#: panel-plugin/settings-dialog.cpp:2418
-msgid "Application icon si_ze:"
-msgstr ""
-
-#. NOTE: launcher_show_name stores "show the real (non-generic) name"; the
-#. checkbox is therefore inverted — checked means "Show generic" (false).
-#: panel-plugin/settings-dialog.cpp:2442
-msgid "Show generic application _names"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2454
-msgid "Show application too_ltips"
-msgstr ""
-
-#. Show descriptions — list-only sub-enable.
-#: panel-plugin/settings-dialog.cpp:2466
-msgid "Show application _descriptions"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2531
-msgid "Opacity"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2534
-msgid "App _box opacity:"
-msgstr ""
-
-#: panel-plugin/settings-dialog.cpp:2590
+#: panel-plugin/ui/properties/sidebar.cpp:62
 msgid "Visuals"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2595
+#: panel-plugin/ui/properties/sidebar.cpp:67
 msgid "Show cate_gory names"
 msgstr ""
 
 #. Category icon size
-#: panel-plugin/settings-dialog.cpp:2608
+#: panel-plugin/ui/properties/sidebar.cpp:80
 msgid "Categ_ory icon size:"
 msgstr ""
 
 #. Sidebar opacity (renamed from "Category opacity"; enable-when-docked).
-#: panel-plugin/settings-dialog.cpp:2632
+#: panel-plugin/ui/properties/sidebar.cpp:104
 msgid "_Sidebar opacity:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2666
+#: panel-plugin/ui/properties/sidebar.cpp:138
 msgid "Sidebar _position:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2671
+#: panel-plugin/ui/properties/sidebar.cpp:143
 msgid "Left"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2672
+#: panel-plugin/ui/properties/sidebar.cpp:144
 msgid "Right"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2706 panel-plugin/settings-dialog.cpp:2916
-msgid "Behaviour"
+#: panel-plugin/ui/properties/sidebar.cpp:145
+#: panel-plugin/ui/properties/user-session.cpp:71
+#: panel-plugin/ui/properties/user-session.cpp:141
+msgid "Hidden"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2709
+#: panel-plugin/ui/properties/sidebar.cpp:181
 msgid "Switch categories by _hovering"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2720
+#: panel-plugin/ui/properties/sidebar.cpp:192
 msgid "Sort ca_tegories"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2733
+#: panel-plugin/ui/properties/sidebar.cpp:205
 msgid "Default category"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2789
+#: panel-plugin/ui/properties/sidebar.cpp:261
 msgid "Recently used"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2792
+#: panel-plugin/ui/properties/sidebar.cpp:264
 msgid "Maximum _items:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2813
+#: panel-plugin/ui/properties/sidebar.cpp:285
 msgid "Include _favorites in \"Recent\""
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2851
-msgid "Places mode"
+#: panel-plugin/ui/properties/user-session.cpp:59
+msgid "Profile"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2854
-msgid "Enable _Places"
+#. Profile position
+#: panel-plugin/ui/properties/user-session.cpp:63
+msgid "_Position:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2866
-msgid "Sections"
+#: panel-plugin/ui/properties/user-session.cpp:70
+#: panel-plugin/ui/properties/user-session.cpp:140
+msgid "Bottom Right"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2872
-msgid "Enable _History section"
+#. Avatar shape (sub-enabled when profile-position != hidden).
+#: panel-plugin/ui/properties/user-session.cpp:81
+msgid "Avatar _shape:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2882
-msgid "Enable _Favourites section"
+#: panel-plugin/ui/properties/user-session.cpp:86
+msgid "Round Picture"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2891
-msgid "Favourite _sync:"
+#: panel-plugin/ui/properties/user-session.cpp:87
+msgid "Square Picture"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2894
-msgid "MeowMenu only"
+#: panel-plugin/ui/properties/user-session.cpp:131
+msgid "Commands"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2895
-msgid "Thunar bookmarks (read-only)"
+#: panel-plugin/ui/properties/user-session.cpp:134
+msgid "_Commands position:"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2903
-msgid "Maximum places _items:"
+#: panel-plugin/ui/properties/user-session.cpp:139
+msgid "Top Right"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2920
-msgid "_Remember last selected mode"
+#: panel-plugin/ui/properties/user-session.cpp:166
+msgid "Place profile, search and session on a single _line"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:2925
-msgid "Show item _metadata"
+#: panel-plugin/ui/properties/user-session.cpp:195
+msgid "Show c_onfirmation dialog"
 msgstr ""
 
-#: panel-plugin/settings.cpp:39
+#: panel-plugin/ui/properties/user-session.cpp:210
+msgid "Session commands"
+msgstr ""
+
+#: panel-plugin/settings.cpp:38
 msgid "Applications"
 msgstr ""
 
-#: panel-plugin/settings.cpp:89 panel-plugin/settings.cpp:96
+#: panel-plugin/settings.cpp:88 panel-plugin/settings.cpp:95
 msgid "Man Pages"
 msgstr ""
 
-#: panel-plugin/settings.cpp:90 panel-plugin/settings.cpp:97
+#: panel-plugin/settings.cpp:89 panel-plugin/settings.cpp:96
 msgid "Search the Web"
 msgstr ""
 
-#: panel-plugin/settings.cpp:91 panel-plugin/settings.cpp:98
+#: panel-plugin/settings.cpp:90 panel-plugin/settings.cpp:97
 msgid "Search for Files"
 msgstr ""
 
-#: panel-plugin/settings.cpp:92 panel-plugin/settings.cpp:99
+#: panel-plugin/settings.cpp:91 panel-plugin/settings.cpp:98
 msgid "Wikipedia"
 msgstr ""
 
-#: panel-plugin/settings.cpp:93 panel-plugin/settings.cpp:100
+#: panel-plugin/settings.cpp:92 panel-plugin/settings.cpp:99
 msgid "Run in Terminal"
 msgstr ""
 
-#: panel-plugin/settings.cpp:94 panel-plugin/settings.cpp:101
+#: panel-plugin/settings.cpp:93 panel-plugin/settings.cpp:100
 msgid "Open URI"
 msgstr ""
 
-#: panel-plugin/settings.cpp:148
+#: panel-plugin/settings.cpp:147
 msgid "_Settings Manager"
 msgstr ""
 
-#: panel-plugin/settings.cpp:150
+#: panel-plugin/settings.cpp:149
 msgid "Failed to open settings manager."
 msgstr ""
 
-#: panel-plugin/settings.cpp:153
+#: panel-plugin/settings.cpp:152
 msgid "_Lock Screen"
 msgstr ""
 
-#: panel-plugin/settings.cpp:155
+#: panel-plugin/settings.cpp:154
 msgid "Failed to lock screen."
 msgstr ""
 
-#: panel-plugin/settings.cpp:158
+#: panel-plugin/settings.cpp:157
 msgid "Switch _User"
 msgstr ""
 
-#: panel-plugin/settings.cpp:160
+#: panel-plugin/settings.cpp:159
 msgid "Failed to switch user."
 msgstr ""
 
-#: panel-plugin/settings.cpp:163
+#: panel-plugin/settings.cpp:162
 msgid "Log _Out"
 msgstr ""
 
-#: panel-plugin/settings.cpp:165 panel-plugin/settings.cpp:200
+#: panel-plugin/settings.cpp:164 panel-plugin/settings.cpp:199
 msgid "Failed to log out."
 msgstr ""
 
-#: panel-plugin/settings.cpp:166
+#: panel-plugin/settings.cpp:165
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:167
+#: panel-plugin/settings.cpp:166
 #, c-format
 msgid "Logging out in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:170
+#: panel-plugin/settings.cpp:169
 msgid "_Restart"
 msgstr ""
 
-#: panel-plugin/settings.cpp:172
+#: panel-plugin/settings.cpp:171
 msgid "Failed to restart."
 msgstr ""
 
-#: panel-plugin/settings.cpp:173
+#: panel-plugin/settings.cpp:172
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:174
+#: panel-plugin/settings.cpp:173
 #, c-format
 msgid "Restarting computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:177
+#: panel-plugin/settings.cpp:176
 msgid "Shut _Down"
 msgstr ""
 
-#: panel-plugin/settings.cpp:179
+#: panel-plugin/settings.cpp:178
 msgid "Failed to shut down."
 msgstr ""
 
-#: panel-plugin/settings.cpp:180
+#: panel-plugin/settings.cpp:179
 msgid "Are you sure you want to shut down?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:181
+#: panel-plugin/settings.cpp:180
 #, c-format
 msgid "Turning off computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:184
+#: panel-plugin/settings.cpp:183
 msgid "Suspe_nd"
 msgstr ""
 
-#: panel-plugin/settings.cpp:186
+#: panel-plugin/settings.cpp:185
 msgid "Failed to suspend."
 msgstr ""
 
-#: panel-plugin/settings.cpp:187
+#: panel-plugin/settings.cpp:186
 msgid "Do you want to suspend to RAM?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:188
+#: panel-plugin/settings.cpp:187
 #, c-format
 msgid "Suspending computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:191
+#: panel-plugin/settings.cpp:190
 msgid "_Hibernate"
 msgstr ""
 
-#: panel-plugin/settings.cpp:193
+#: panel-plugin/settings.cpp:192
 msgid "Failed to hibernate."
 msgstr ""
 
-#: panel-plugin/settings.cpp:194
+#: panel-plugin/settings.cpp:193
 msgid "Do you want to suspend to disk?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:195
+#: panel-plugin/settings.cpp:194
 #, c-format
 msgid "Hibernating computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:198
+#: panel-plugin/settings.cpp:197
 msgid "Log Ou_t..."
 msgstr ""
 
-#: panel-plugin/settings.cpp:203
+#: panel-plugin/settings.cpp:202
 msgid "_Edit Applications"
 msgstr ""
 
-#: panel-plugin/settings.cpp:205
+#: panel-plugin/settings.cpp:204
 msgid "Failed to launch menu editor."
 msgstr ""
 
-#: panel-plugin/settings.cpp:208
+#: panel-plugin/settings.cpp:207
 msgid "Edit _Profile"
 msgstr ""
 
-#: panel-plugin/settings.cpp:210
+#: panel-plugin/settings.cpp:209
 msgid "Failed to edit profile."
 msgstr ""
 
-#: panel-plugin/window.cpp:412
+#: panel-plugin/core/window.cpp:526
 msgid "Apps"
 msgstr ""
 
-#: panel-plugin/window.cpp:1799
+#: panel-plugin/core/window-pages.cpp:279
 msgid "Search places…"
 msgstr ""
 
-#: panel-plugin/window.cpp:1800
+#: panel-plugin/core/window-pages.cpp:280
 msgid "Search applications…"
 msgstr ""
 
-#: panel-plugin/xfce4-popup-meowmenu.cpp:110
+#: panel-plugin/core/xfce4-popup-meowmenu.cpp:110
 msgid "Popup menu at current mouse position"
 msgstr ""
 
-#: panel-plugin/xfce4-popup-meowmenu.cpp:111
+#: panel-plugin/core/xfce4-popup-meowmenu.cpp:111
 msgid "Popup menu at center of screen"
 msgstr ""
 
-#: panel-plugin/xfce4-popup-meowmenu.cpp:112
+#: panel-plugin/core/xfce4-popup-meowmenu.cpp:112
 msgid "Print available menu instance IDs"
 msgstr ""
 
-#: panel-plugin/xfce4-popup-meowmenu.cpp:113
+#: panel-plugin/core/xfce4-popup-meowmenu.cpp:113
 msgid "Choose which menu to popup by instance ID"
 msgstr ""
 
-#: panel-plugin/xfce4-popup-meowmenu.cpp:114
+#: panel-plugin/core/xfce4-popup-meowmenu.cpp:114
 msgid "Print version information and exit"
 msgstr ""
 
-#: panel-plugin/whiskermenu.desktop.in:5
+#: panel-plugin/meowmenu.desktop.in:5
 msgid "Show a menu to easily access installed applications"
 msgstr ""

--- a/tests/test_focus_router.cpp
+++ b/tests/test_focus_router.cpp
@@ -1,9 +1,10 @@
 /*
- * Headless tests for the Tab-cycle resolution helpers declared in
+ * Headless tests for the focus-area resolution helpers declared in
  * panel-plugin/core/window-keyboard.h. No GTK widgets are instantiated;
  * only the VisibilityMask/MenuState/Zone inputs are fabricated.
  *
- * Covers contracts/focus-router.md §"Test plan".
+ * Covers the four-zone Ctrl+Tab cycle (contracts/area-cycle.md §"Test plan")
+ * and the bare-Tab decision rule (contracts/tab-mode-toggle.md §"Test plan").
  */
 
 #include "core/window-keyboard.h"
@@ -15,6 +16,8 @@
 using WhiskerMenu::Keyboard::Direction;
 using WhiskerMenu::Keyboard::MenuState;
 using WhiskerMenu::Keyboard::next_zone;
+using WhiskerMenu::Keyboard::tab_action;
+using WhiskerMenu::Keyboard::TabAction;
 using WhiskerMenu::Keyboard::VisibilityMask;
 using WhiskerMenu::Keyboard::Zone;
 using WhiskerMenu::Keyboard::zone_active;
@@ -38,7 +41,6 @@ const char* zone_name(Zone z)
 	case Zone::Search:  return "Search";
 	case Zone::Results: return "Results";
 	case Zone::Sidebar: return "Sidebar";
-	case Zone::Mode:    return "Mode";
 	case Zone::Profile: return "Profile";
 	}
 	return "?";
@@ -67,7 +69,6 @@ void canonical_full_loop()
 	Zone z = Zone::Search;
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Results);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Sidebar);
-	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Mode);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Profile);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Forward); EQZ(z, Zone::Search);
 }
@@ -77,7 +78,6 @@ void reverse_full_loop()
 	VisibilityMask mask;
 	Zone z = Zone::Search;
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Profile);
-	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Mode);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Sidebar);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Results);
 	z = next_zone(mask, MenuState::Browsing, z, Direction::Backward); EQZ(z, Zone::Search);
@@ -86,9 +86,11 @@ void reverse_full_loop()
 
 void sidebar_skipped_when_searching()
 {
+	// Sidebar is inert while Searching, so Forward from Results skips it
+	// and lands on Profile (the mode toggle is no longer a cycle stop).
 	VisibilityMask mask;
 	EQZ(next_zone(mask, MenuState::Searching, Zone::Results, Direction::Forward),
-	    Zone::Mode);
+	    Zone::Profile);
 }
 
 void sidebar_rejoined_when_browsing()
@@ -100,26 +102,29 @@ void sidebar_rejoined_when_browsing()
 
 void hidden_profile_skipped()
 {
+	// With Profile hidden, Forward from Sidebar wraps past the absent
+	// Profile back to Search.
 	VisibilityMask mask;
 	mask.profile = false;
-	EQZ(next_zone(mask, MenuState::Browsing, Zone::Mode, Direction::Forward),
+	EQZ(next_zone(mask, MenuState::Browsing, Zone::Sidebar, Direction::Forward),
 	    Zone::Search);
 }
 
-void hidden_sidebar_and_mode()
+void hidden_sidebar()
 {
+	// Sidebar hidden → Forward from Results lands on Profile.
 	VisibilityMask mask;
 	mask.sidebar = false;
-	mask.mode = false;
 	EQZ(next_zone(mask, MenuState::Browsing, Zone::Results, Direction::Forward),
 	    Zone::Profile);
 }
 
-void hidden_profile_and_mode_searching()
+void hidden_profile_searching()
 {
+	// Profile hidden and Sidebar inert (Searching) → Forward from Results
+	// wraps to Search.
 	VisibilityMask mask;
 	mask.profile = false;
-	mask.mode = false;
 	EQZ(next_zone(mask, MenuState::Searching, Zone::Results, Direction::Forward),
 	    Zone::Search);
 }
@@ -128,10 +133,10 @@ void current_is_inert_zone()
 {
 	// Sidebar just became inert (user typed first character). Forward
 	// from inert Sidebar should land on the first active zone after it
-	// in canonical order, which is Mode.
+	// in canonical order, which is Profile (Mode is no longer a stop).
 	VisibilityMask mask;
 	EQZ(next_zone(mask, MenuState::Searching, Zone::Sidebar, Direction::Forward),
-	    Zone::Mode);
+	    Zone::Profile);
 }
 
 void ltr_and_rtl_equivalence()
@@ -146,20 +151,21 @@ void ltr_and_rtl_equivalence()
 	EQZ(ltr, rtl);
 }
 
-void four_tabs_visit_every_visible()
+void three_tabs_visit_every_visible()
 {
-	// SC-006: starting from Search in an all-visible Browsing menu,
-	// four Forward Tab steps must visit Results, Sidebar, Mode, Profile.
+	// SC-006: starting from Search in an all-visible Browsing menu, three
+	// Forward steps must visit the other three zones: Results, Sidebar,
+	// Profile (the four-zone cycle has no Mode stop).
 	VisibilityMask mask;
-	bool visited[5] = { false, false, false, false, false };
+	bool visited[4] = { false, false, false, false };
 	Zone z = Zone::Search;
 	visited[static_cast<unsigned>(z)] = true;
-	for (int i = 0; i < 4; ++i)
+	for (int i = 0; i < 3; ++i)
 	{
 		z = next_zone(mask, MenuState::Browsing, z, Direction::Forward);
 		visited[static_cast<unsigned>(z)] = true;
 	}
-	for (unsigned i = 0; i < 5; ++i)
+	for (unsigned i = 0; i < 4; ++i)
 	{
 		CHECK(visited[i]);
 	}
@@ -167,10 +173,9 @@ void four_tabs_visit_every_visible()
 
 void all_optional_zones_hidden()
 {
-	// Profile + Mode + Sidebar hidden → cycle reduces to Search ↔ Results.
+	// Sidebar + Profile hidden → cycle reduces to Search ↔ Results.
 	VisibilityMask mask;
 	mask.sidebar = false;
-	mask.mode = false;
 	mask.profile = false;
 	EQZ(next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Forward),
 	    Zone::Results);
@@ -178,6 +183,14 @@ void all_optional_zones_hidden()
 	    Zone::Search);
 	EQZ(next_zone(mask, MenuState::Browsing, Zone::Search, Direction::Backward),
 	    Zone::Results);
+}
+
+void tab_action_rule()
+{
+	// FR-006: Tab toggles the mode when Places is available and is inert
+	// otherwise — it never falls back to area cycling.
+	CHECK(tab_action(true)  == TabAction::ToggleMode);
+	CHECK(tab_action(false) == TabAction::Inert);
 }
 
 void zone_active_basic()
@@ -201,12 +214,13 @@ int main()
 	sidebar_skipped_when_searching();
 	sidebar_rejoined_when_browsing();
 	hidden_profile_skipped();
-	hidden_sidebar_and_mode();
-	hidden_profile_and_mode_searching();
+	hidden_sidebar();
+	hidden_profile_searching();
 	current_is_inert_zone();
 	ltr_and_rtl_equivalence();
-	four_tabs_visit_every_visible();
+	three_tabs_visit_every_visible();
 	all_optional_zones_hidden();
+	tab_action_rule();
 	zone_active_basic();
 
 	if (g_failures != 0)

--- a/tests/test_places.cpp
+++ b/tests/test_places.cpp
@@ -57,6 +57,118 @@ static std::vector<std::string> filter_existing_dirs(
 }
 
 // ---------------------------------------------------------------------------
+// Stand-in for PlacesItem's availability-driven presentation (places-item.cpp):
+// an available item keeps its plain display name; a missing item is wrapped in
+// muted Pango markup with the name escaped, and its tooltip names the target and
+// marks it missing. Mirrors the production logic without constructing GTK.
+// ---------------------------------------------------------------------------
+static std::string places_display_markup(const char* name, bool exists)
+{
+	const char* label = name ? name : "";
+	if (exists)
+	{
+		return label;
+	}
+	gchar* escaped = g_markup_escape_text(label, -1);
+	gchar* markup = g_strdup_printf("<span alpha=\"55%%\">%s</span>",
+			escaped ? escaped : "");
+	std::string out = markup ? markup : "";
+	g_free(markup);
+	g_free(escaped);
+	return out;
+}
+
+static std::string places_missing_tooltip(const char* target)
+{
+	gchar* tip = g_strdup_printf("%s (missing)", target ? target : "");
+	std::string out = tip ? tip : "";
+	g_free(tip);
+	return out;
+}
+
+// Validate Pango span well-formedness using GLib's markup parser (no Pango
+// dependency): confirm the string parses and its root element is <span> with an
+// "alpha" attribute.
+static bool is_valid_alpha_span(const std::string& markup)
+{
+	struct Captured { std::string element; bool has_alpha = false; };
+	Captured cap;
+
+	GMarkupParser parser = {};
+	parser.start_element = [](GMarkupParseContext*, const gchar* name,
+			const gchar** attr_names, const gchar** attr_values,
+			gpointer user_data, GError**)
+	{
+		auto* c = static_cast<Captured*>(user_data);
+		if (c->element.empty())
+		{
+			c->element = name ? name : "";
+			for (int i = 0; attr_names && attr_names[i]; ++i)
+			{
+				if (g_strcmp0(attr_names[i], "alpha") == 0)
+				{
+					c->has_alpha = true;
+				}
+			}
+			(void) attr_values;
+		}
+	};
+
+	GMarkupParseContext* ctx = g_markup_parse_context_new(&parser,
+			GMarkupParseFlags(0), &cap, nullptr);
+	gboolean ok = g_markup_parse_context_parse(ctx, markup.c_str(), -1, nullptr)
+			&& g_markup_parse_context_end_parse(ctx, nullptr);
+	g_markup_parse_context_free(ctx);
+
+	return ok && cap.element == "span" && cap.has_alpha;
+}
+
+// ---------------------------------------------------------------------------
+
+static void test_missing_item_markup_is_muted_and_escaped()
+{
+	// A name with markup-significant characters must be escaped inside the span.
+	const std::string markup = places_display_markup("Tom & Jerry <draft>", false);
+	assert(is_valid_alpha_span(markup));
+	assert(markup.find("&amp;") != std::string::npos);
+	assert(markup.find("&lt;draft&gt;") != std::string::npos);
+	// The raw, unescaped ampersand must not survive into the markup.
+	assert(markup.find("& Jerry") == std::string::npos);
+}
+
+static void test_missing_item_tooltip_names_target()
+{
+	const std::string tip = places_missing_tooltip("/home/u/Docs/report.odt");
+	assert(tip.find("/home/u/Docs/report.odt") != std::string::npos);
+	assert(tip.find("missing") != std::string::npos);
+}
+
+static void test_available_item_keeps_plain_label()
+{
+	// An available item's label is the plain display text, untouched.
+	const std::string label = places_display_markup("report.odt", true);
+	assert(label == "report.odt");
+	assert(label.find("<span") == std::string::npos);
+}
+
+static void test_missing_treatment_is_source_agnostic()
+{
+	// A missing favourite and a missing recent entry pointing at the same
+	// target get an identical muted label and "missing" tooltip — one shared
+	// treatment, regardless of which section produced the item (FR-002).
+	const char* name = "Project";
+	const char* target = "/srv/Project";
+
+	const std::string recent_markup = places_display_markup(name, false);
+	const std::string favourite_markup = places_display_markup(name, false);
+	assert(recent_markup == favourite_markup);
+
+	const std::string recent_tip = places_missing_tooltip(target);
+	const std::string favourite_tip = places_missing_tooltip(target);
+	assert(recent_tip == favourite_tip);
+}
+
+// ---------------------------------------------------------------------------
 
 static void test_search_empty_filter_matches_everything()
 {
@@ -115,6 +227,10 @@ static void test_home_filter_existing_dirs()
 
 int main()
 {
+	test_missing_item_markup_is_muted_and_escaped();
+	test_missing_item_tooltip_names_target();
+	test_available_item_keeps_plain_label();
+	test_missing_treatment_is_source_agnostic();
 	test_search_empty_filter_matches_everything();
 	test_search_case_insensitive_ascii();
 	test_search_utf8();


### PR DESCRIPTION
- Tab now switches directly between Applications and Places
- Ctrl+Tab cycles focus areas (zones)
- show missing Places items as muted, with their Open action disabled
- keep "Open containing folder" available for missing items