### PR TITLE
Release v0.5.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
 MEOW MENU DEVELOPMENT
+0.5.5 (2026-06-03)
+=====
+- menu background fallback now matches the active theme (light or dark)
+- preferences and "What's New" windows no longer open off-screen on HiDPI displays
+- audited all hard-coded pixel constants; no scaling bugs found
+
 0.5.4 (2026-06-01)
 =====
 - Tab now switches directly between Applications and Places

--- a/panel-plugin/core/plugin.cpp
+++ b/panel-plugin/core/plugin.cpp
@@ -29,6 +29,7 @@
 #include "settings-dialog.h"
 #include "ui/slot.h"
 #include "window.h"
+#include "window-size-clamp.h"
 
 #include <glib/gstdio.h>
 #include <libxfce4ui/libxfce4ui.h>
@@ -454,7 +455,37 @@ static void show_news_dialog(GtkWindow* parent)
 		static_cast<GtkDialogFlags>(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
 		_("Close"), GTK_RESPONSE_CLOSE,
 		nullptr);
-	gtk_window_set_default_size(GTK_WINDOW(dialog), 520, 420);
+	// Clamp the 520x420 logical default to the active monitor's work area so
+	// the dialog can never open off-screen or larger than the screen at very
+	// large effective scales. Shrink-only, so at a normal 1x work area the
+	// size passes through unchanged.
+	//
+	// HACK: the dialog is not realized yet here, so we resolve the monitor
+	// under its (already-shown) parent when possible, falling back to the
+	// primary (then first) monitor. If no monitor can be resolved at all,
+	// the work area is left 0x0, which the clamp treats as "no constraint"
+	// and returns the size as-is.
+	{
+		GdkRectangle workarea = { 0, 0, 0, 0 };
+		GdkDisplay* display = gtk_widget_get_display(dialog);
+		GdkMonitor* monitor = nullptr;
+		if (parent)
+		{
+			if (GdkWindow* pwin = gtk_widget_get_window(GTK_WIDGET(parent)))
+				monitor = gdk_display_get_monitor_at_window(display, pwin);
+		}
+		if (!monitor)
+			monitor = gdk_display_get_primary_monitor(display);
+		if (!monitor && gdk_display_get_n_monitors(display) > 0)
+			monitor = gdk_display_get_monitor(display, 0);
+		if (monitor)
+			gdk_monitor_get_workarea(monitor, &workarea);
+
+		int clamped_w = 0, clamped_h = 0;
+		meow::clamp_default_size(520, 420, workarea.width, workarea.height,
+			&clamped_w, &clamped_h);
+		gtk_window_set_default_size(GTK_WINDOW(dialog), clamped_w, clamped_h);
+	}
 
 	GtkWidget* scrolled = gtk_scrolled_window_new(nullptr, nullptr);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),

--- a/panel-plugin/core/theme-fallback.cpp
+++ b/panel-plugin/core/theme-fallback.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "theme-fallback.h"
+
+namespace WhiskerMenu
+{
+
+namespace
+{
+
+// The two fixed neutral greys the chooser may return. Dark matches the
+// historical hard-coded seed exactly, so the dark-theme and undeterminable
+// paths are bit-for-bit unchanged; light is its counterpart for light themes.
+const GdkRGBA MEOW_FALLBACK_DARK  = { 0.12,  0.12,  0.12,  1.0 }; // rgb(31,31,31)
+const GdkRGBA MEOW_FALLBACK_LIGHT = { 0.961, 0.961, 0.961, 1.0 }; // rgb(245,245,245)
+
+} // namespace
+
+double meow_relative_luminance(const GdkRGBA* colour)
+{
+	// Rec. 709 luma. Components are GTK-supplied in [0,1]; we deliberately do
+	// not re-clamp, matching how the caller already trusts the lookup range.
+	return 0.2126 * colour->red + 0.7152 * colour->green + 0.0722 * colour->blue;
+}
+
+GdkRGBA meow_choose_background_fallback(gboolean have_fg, const GdkRGBA* fg,
+                                        gboolean prefer_dark)
+{
+	if (have_fg)
+	{
+		// Light text implies a dark theme and vice versa. The Y >= 0.5 tie
+		// resolves to "light text" → dark background, so a mid-grey text
+		// colour keeps the safe dark surface (research R3).
+		return meow_relative_luminance(fg) >= 0.5 ? MEOW_FALLBACK_DARK
+		                                           : MEOW_FALLBACK_LIGHT;
+	}
+
+	// NOTE: prefer_dark is a one-way dark confirmation, never a light signal.
+	// TRUE selects dark; FALSE/unknown both fall through to the dark default
+	// below, because FALSE is the GTK default for most themes regardless of
+	// their real lightness and so is not trustworthy (research R4). The light
+	// fallback is therefore reachable only via the foreground-luminance branch
+	// above — prefer_dark can confirm dark but can never flip to light.
+	if (prefer_dark)
+	{
+		return MEOW_FALLBACK_DARK;
+	}
+
+	// FR-004 safe default: when no signal is usable, keep today's dark grey so
+	// the menu is always painted with a known-good, opaque colour.
+	return MEOW_FALLBACK_DARK;
+}
+
+} // namespace WhiskerMenu

--- a/panel-plugin/core/theme-fallback.h
+++ b/panel-plugin/core/theme-fallback.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEOWMENU_CORE_THEME_FALLBACK_H
+#define MEOWMENU_CORE_THEME_FALLBACK_H
+
+#include <gdk/gdk.h>
+
+namespace WhiskerMenu
+{
+
+/* meow_relative_luminance:
+ * @colour: sRGB components in [0,1]; alpha ignored. Must not be NULL.
+ *
+ * Computes the perceived lightness of a colour so a theme can be classified
+ * as light or dark from its text colour.
+ *
+ * Returns: Rec. 709 relative luminance Y = 0.2126R + 0.7152G + 0.0722B over
+ * the [0,1] components (no re-clamp).
+ */
+double meow_relative_luminance(const GdkRGBA* colour);
+
+/* meow_choose_background_fallback:
+ * @have_fg: whether a foreground/text colour was resolved from the theme.
+ * @fg: the foreground colour; read only when @have_fg is TRUE (may be NULL
+ *      otherwise).
+ * @prefer_dark: value of the gtk-application-prefer-dark-theme setting; used
+ *               only as a last-but-one signal when @have_fg is FALSE.
+ *
+ * Picks the base background colour to use when the theme's own background
+ * colour lookup failed. The result is one of exactly two fixed neutral greys
+ * and is always opaque, so the menu is never left unpainted.
+ *
+ * Returns: GdkRGBA dark rgb(31,31,31) or light rgb(245,245,245), alpha 1.0.
+ */
+GdkRGBA meow_choose_background_fallback(gboolean have_fg, const GdkRGBA* fg,
+                                        gboolean prefer_dark);
+
+} // namespace WhiskerMenu
+
+#endif // MEOWMENU_CORE_THEME_FALLBACK_H

--- a/panel-plugin/core/window-size-clamp.cpp
+++ b/panel-plugin/core/window-size-clamp.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "window-size-clamp.h"
+
+namespace meow
+{
+
+namespace
+{
+
+/* clamp_axis:
+ * @desired: intended logical size on this axis.
+ * @workarea: the monitor's usable size on this axis; <= 0 means "no
+ *            constraint" (the monitor could not be resolved).
+ *
+ * Returns the largest size <= @desired that still leaves a small edge margin
+ * inside @workarea. Shrink-only: when @desired already fits, it is returned
+ * unchanged, so the standard-DPI layout never moves. The result is floored at
+ * 1 so a tiny or garbage work area can never collapse the window to zero.
+ */
+int clamp_axis(int desired, int workarea)
+{
+	// No usable constraint on this axis: keep the caller's intent verbatim.
+	if (workarea <= 0)
+		return desired;
+
+	// Reserve ~4% of the work area as an edge margin so the window is not
+	// flush to the screen edge. The exact fraction is not contractual; the
+	// guarantees the test pins are shrink-only, on-screen, and never-zero.
+	const int margin = workarea / 25;
+	const int available = workarea - margin;
+
+	int out = desired < available ? desired : available;
+	if (out < 1)
+		out = 1;
+	return out;
+}
+
+} // namespace
+
+void clamp_default_size(int desired_w, int desired_h,
+                        int workarea_w, int workarea_h,
+                        int* out_w, int* out_h)
+{
+	*out_w = clamp_axis(desired_w, workarea_w);
+	*out_h = clamp_axis(desired_h, workarea_h);
+}
+
+} // namespace meow

--- a/panel-plugin/core/window-size-clamp.h
+++ b/panel-plugin/core/window-size-clamp.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEOWMENU_CORE_WINDOW_SIZE_CLAMP_H
+#define MEOWMENU_CORE_WINDOW_SIZE_CLAMP_H
+
+namespace meow
+{
+
+/* clamp_default_size:
+ * @desired_w / @desired_h: the window's intended default size in *logical*
+ *   pixels (e.g. 820x600 for the preferences window).
+ * @workarea_w / @workarea_h: the active monitor's usable area in logical
+ *   pixels; pass 0 (or negative) on an axis to mean "no constraint on that
+ *   axis" (e.g. the monitor could not be resolved).
+ * @out_w / @out_h: receive the clamped size; never NULL.
+ *
+ * Shrinks @desired_* so the window never exceeds the work area, leaving a small
+ * margin so the window is not flush to the screen edge. Never enlarges: at
+ * realistic 1x work areas the output equals the input, guaranteeing no change
+ * to the standard-DPI layout. Output is always >= 1 on each axis when the
+ * corresponding desired input is >= 1.
+ */
+void clamp_default_size(int desired_w, int desired_h,
+                        int workarea_w, int workarea_h,
+                        int* out_w, int* out_h);
+
+} // namespace meow
+
+#endif // MEOWMENU_CORE_WINDOW_SIZE_CLAMP_H

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -32,6 +32,7 @@
 #include "resizer.h"
 #include "search/search-page.h"
 #include "settings.h"
+#include "theme-fallback.h"
 #include "ui/slot.h"
 #include "search/unified-bar.h"
 #include "window-keyboard.h"
@@ -1809,10 +1810,51 @@ void WhiskerMenu::Window::update_background_css()
 	}
 
 	GtkStyleContext* context = gtk_widget_get_style_context(GTK_WIDGET(m_window));
+	// NOTE: the fallback below is recomputed from scratch on every call and
+	// never cached, so a live light<->dark theme switch is tracked by the
+	// existing callers of this method (on_screen_changed,
+	// on_state_flags_changed, the xfconf property-changed handler, and the
+	// initial setup) without introducing any new refresh signal.
 	GdkRGBA bg = { 0.12, 0.12, 0.12, 1.0 };
-	if (!gtk_style_context_lookup_color(context, "theme_bg_color", &bg))
+	gboolean bg_found = gtk_style_context_lookup_color(context, "theme_bg_color", &bg);
+	if (!bg_found)
 	{
-		gtk_style_context_lookup_color(context, "bg_color", &bg);
+		bg_found = gtk_style_context_lookup_color(context, "bg_color", &bg);
+	}
+
+	// TEMPORARY DIAGNOSTIC — remove before merge
+	{
+		gchar* theme = nullptr;
+		gboolean prefer_dark = FALSE;
+		g_object_get(gtk_settings_get_default(),
+			"gtk-theme-name", &theme,
+			"gtk-application-prefer-dark-theme", &prefer_dark, nullptr);
+		gboolean realized = gtk_widget_get_realized(GTK_WIDGET(m_window));
+		g_message("update_background_css: theme=%s prefer_dark=%d realized=%d bg_found=%d bg=rgb(%d,%d,%d)",
+			theme ? theme : "(null)", (int)prefer_dark, (int)realized, (int)bg_found,
+			(int)(bg.red * 255 + 0.5), (int)(bg.green * 255 + 0.5), (int)(bg.blue * 255 + 0.5));
+		g_free(theme);
+	}
+
+	if (!bg_found)
+	{
+		// Both background lookups failed. The old code kept the unconditional
+		// dark seed here, so a light theme that omits the key painted a dark
+		// menu — the reported defect. Instead infer the theme's lightness from
+		// its foreground/text colour, and failing that the prefer-dark setting,
+		// then substitute a matching neutral grey for the seed.
+		GdkRGBA fg;
+		gboolean have_fg = gtk_style_context_lookup_color(context, "theme_fg_color", &fg);
+		if (!have_fg)
+		{
+			have_fg = gtk_style_context_lookup_color(context, "fg_color", &fg);
+		}
+
+		gboolean prefer_dark = FALSE;
+		g_object_get(gtk_settings_get_default(),
+			"gtk-application-prefer-dark-theme", &prefer_dark, nullptr);
+
+		bg = meow_choose_background_fallback(have_fg, &fg, prefer_dark);
 	}
 
 	const int red   = CLAMP(static_cast<int>(bg.red   * 255.0 + 0.5), 0, 255);

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -24,6 +24,7 @@ plugin_sources = [
   'places/places-page.cpp',
   'core/plugin.cpp',
   'core/theme-fallback.cpp',
+  'core/window-size-clamp.cpp',
   'profile.cpp',
   'search/query.cpp',
   'launcher/recent-page.cpp',

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -23,6 +23,7 @@ plugin_sources = [
   'places/places-item.cpp',
   'places/places-page.cpp',
   'core/plugin.cpp',
+  'core/theme-fallback.cpp',
   'profile.cpp',
   'search/query.cpp',
   'launcher/recent-page.cpp',

--- a/panel-plugin/settings-dialog.cpp
+++ b/panel-plugin/settings-dialog.cpp
@@ -27,6 +27,7 @@
 #include "settings.h"
 #include "ui/slot.h"
 #include "core/window.h"
+#include "core/window-size-clamp.h"
 #include "presets/preset.h"
 #include "presets/preset-io.h"
 #include "search/unified-bar.h"
@@ -114,7 +115,34 @@ SettingsDialog::SettingsDialog(Settings* settings, Plugin* plugin) :
 
 	GtkBox* contents = GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(m_window)));
 	gtk_box_pack_start(contents, GTK_WIDGET(hbox), true, true, 0);
-	gtk_window_set_default_size(GTK_WINDOW(m_window), 820, 600);
+	// Clamp the 820x600 logical default to the active monitor's work area so
+	// the preferences window can never open off-screen or larger than the
+	// screen at very large effective scales. Shrink-only, so at a normal 1x
+	// work area the size passes through unchanged.
+	//
+	// HACK: the window is not realized yet here, so its own GdkWindow is not
+	// available; we resolve the monitor under it when possible and otherwise
+	// fall back to the primary (then first) monitor. If no monitor can be
+	// resolved at all (no display / headless), the work area is left 0x0,
+	// which the clamp treats as "no constraint" and returns the size as-is.
+	{
+		GdkRectangle workarea = { 0, 0, 0, 0 };
+		GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(m_window));
+		GdkMonitor* monitor = nullptr;
+		if (GdkWindow* gdkwin = gtk_widget_get_window(GTK_WIDGET(m_window)))
+			monitor = gdk_display_get_monitor_at_window(display, gdkwin);
+		if (!monitor)
+			monitor = gdk_display_get_primary_monitor(display);
+		if (!monitor && gdk_display_get_n_monitors(display) > 0)
+			monitor = gdk_display_get_monitor(display, 0);
+		if (monitor)
+			gdk_monitor_get_workarea(monitor, &workarea);
+
+		int clamped_w = 0, clamped_h = 0;
+		meow::clamp_default_size(820, 600, workarea.width, workarea.height,
+			&clamped_w, &clamped_h);
+		gtk_window_set_default_size(GTK_WINDOW(m_window), clamped_w, clamped_h);
+	}
 
 	// Mirror live menu-width / menu-height changes (e.g. drag-resizing the
 	// menu window) into the spin buttons. The Settings::property_changed slot

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -238,3 +238,21 @@ test_theme_fallback = executable(
 )
 
 test('theme_fallback', test_theme_fallback)
+
+# test_window_size_clamp: headless coverage of the pure window default-size
+# clamp in panel-plugin/core/window-size-clamp.cpp (HiDPI defensive guard,
+# cases C1..C7). Pulls only the GTK-free helper translation unit; no display
+# server, no GTK widgets.
+test_window_size_clamp_sources = [
+  'test_window_size_clamp.cpp',
+  '..' / 'panel-plugin' / 'core' / 'window-size-clamp.cpp',
+]
+
+test_window_size_clamp = executable(
+  'test_window_size_clamp',
+  test_window_size_clamp_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [],
+)
+
+test('window_size_clamp', test_window_size_clamp)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -221,3 +221,20 @@ test_key_routing = executable(
 )
 
 test('key_routing', test_key_routing)
+
+# test_theme_fallback: headless coverage of the theme-aware background
+# fallback chooser in panel-plugin/core/theme-fallback.cpp. Pulls only the
+# pure helper translation unit; no display server, no GTK widgets.
+test_theme_fallback_sources = [
+  'test_theme_fallback.cpp',
+  '..' / 'panel-plugin' / 'core' / 'theme-fallback.cpp',
+]
+
+test_theme_fallback = executable(
+  'test_theme_fallback',
+  test_theme_fallback_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [glib, gtk],
+)
+
+test('theme_fallback', test_theme_fallback)

--- a/tests/test_theme_fallback.cpp
+++ b/tests/test_theme_fallback.cpp
@@ -1,0 +1,118 @@
+/*
+ * Headless tests for the theme-aware background fallback chooser declared in
+ * panel-plugin/core/theme-fallback.h. No GTK widgets are instantiated; only
+ * GdkRGBA values and the prefer-dark boolean are fabricated.
+ *
+ * Asserts the normative decision table in
+ * .specify/specs/018-theme-aware-fallback/contracts/fallback-decision.md.
+ */
+
+#include "core/theme-fallback.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using WhiskerMenu::meow_choose_background_fallback;
+using WhiskerMenu::meow_relative_luminance;
+
+namespace
+{
+
+int g_failures = 0;
+
+#define CHECK(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			++g_failures; \
+		} \
+	} while (0)
+
+// Exact fallback constants the chooser must return (guards invariant C2).
+const GdkRGBA DARK  = { 0.12,  0.12,  0.12,  1.0 }; // rgb(31,31,31)
+const GdkRGBA LIGHT = { 0.961, 0.961, 0.961, 1.0 }; // rgb(245,245,245)
+
+bool rgba_equal(const GdkRGBA& a, const GdkRGBA& b)
+{
+	return a.red == b.red && a.green == b.green
+	    && a.blue == b.blue && a.alpha == b.alpha;
+}
+
+GdkRGBA make_rgb(double r, double g, double b)
+{
+	GdkRGBA c = { r, g, b, 1.0 };
+	return c;
+}
+
+// Decision-table row 2: light text → dark background.
+void light_text_gives_dark()
+{
+	GdkRGBA fg = make_rgb(238.0 / 255.0, 238.0 / 255.0, 238.0 / 255.0);
+	CHECK(rgba_equal(meow_choose_background_fallback(TRUE, &fg, FALSE), DARK));
+}
+
+// Decision-table row 3: dark text → light background.
+void dark_text_gives_light()
+{
+	GdkRGBA fg = make_rgb(34.0 / 255.0, 34.0 / 255.0, 34.0 / 255.0);
+	CHECK(rgba_equal(meow_choose_background_fallback(TRUE, &fg, FALSE), LIGHT));
+}
+
+// Decision-table row 4: no fg + prefer-dark TRUE → dark.
+void no_fg_prefer_dark_gives_dark()
+{
+	CHECK(rgba_equal(meow_choose_background_fallback(FALSE, nullptr, TRUE), DARK));
+}
+
+// Decision-table row 5: no fg + prefer-dark FALSE/unknown → dark (FR-004).
+void no_fg_no_prefer_gives_dark()
+{
+	CHECK(rgba_equal(meow_choose_background_fallback(FALSE, nullptr, FALSE), DARK));
+}
+
+// Luminance ordering sanity plus the documented Y == 0.5 tie behaviour.
+void luminance_ordering()
+{
+	GdkRGBA white = make_rgb(1.0, 1.0, 1.0);
+	GdkRGBA black = make_rgb(0.0, 0.0, 0.0);
+	CHECK(meow_relative_luminance(&white) > 0.5);
+	CHECK(meow_relative_luminance(&black) < 0.5);
+
+	// A grey whose luminance lands exactly on the boundary classifies as
+	// "light text" → dark background (the Y >= 0.5 tie). Luminance weights
+	// sum to 1.0, so an equal-component grey at 0.5 yields Y == 0.5.
+	GdkRGBA boundary = make_rgb(0.5, 0.5, 0.5);
+	CHECK(meow_relative_luminance(&boundary) == 0.5);
+	CHECK(rgba_equal(meow_choose_background_fallback(TRUE, &boundary, FALSE), DARK));
+}
+
+// Invariant C2: the returned colours are exactly the two constants, alpha 1.0.
+void returns_exact_constants()
+{
+	GdkRGBA light_fg = make_rgb(0.9, 0.9, 0.9);
+	GdkRGBA dark_fg  = make_rgb(0.1, 0.1, 0.1);
+	GdkRGBA d = meow_choose_background_fallback(TRUE, &light_fg, FALSE);
+	GdkRGBA l = meow_choose_background_fallback(TRUE, &dark_fg, FALSE);
+
+	CHECK(d.red == 0.12 && d.green == 0.12 && d.blue == 0.12 && d.alpha == 1.0);
+	CHECK(l.red == 0.961 && l.green == 0.961 && l.blue == 0.961 && l.alpha == 1.0);
+}
+
+} // namespace
+
+int main()
+{
+	light_text_gives_dark();
+	dark_text_gives_light();
+	no_fg_prefer_dark_gives_dark();
+	no_fg_no_prefer_gives_dark();
+	luminance_ordering();
+	returns_exact_constants();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_theme_fallback: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_theme_fallback: ok\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_window_size_clamp.cpp
+++ b/tests/test_window_size_clamp.cpp
@@ -1,0 +1,126 @@
+/*
+ * Headless tests for the pure window default-size clamp declared in
+ * panel-plugin/core/window-size-clamp.h. No GTK/GDK types are used; only the
+ * integer logical sizes the helper consumes are fabricated.
+ *
+ * Asserts the normative decision table (C1..C7) in
+ * .specify/specs/019-hidpi-audit/contracts/size-clamp.md. The cases pin
+ * behaviour, not the exact edge-margin fraction.
+ */
+
+#include "core/window-size-clamp.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using meow::clamp_default_size;
+
+namespace
+{
+
+int g_failures = 0;
+
+#define CHECK(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			++g_failures; \
+		} \
+	} while (0)
+
+// C1: desired fits comfortably in a large work area -> unchanged. This is the
+// 1x / large-screen no-op that guarantees the standard-DPI layout never moves.
+void c1_fits_unchanged()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, 3840, 2160, &w, &h);
+	CHECK(w == 820);
+	CHECK(h == 600);
+}
+
+// C2: unresolved monitor reports 0x0 -> "no constraint" -> unchanged.
+void c2_unresolved_monitor_unchanged()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, 0, 0, &w, &h);
+	CHECK(w == 820);
+	CHECK(h == 600);
+}
+
+// C3: oversized against a small work area -> shrunk to fit on both axes,
+// staying within the work area and never collapsing below 1.
+void c3_oversized_shrinks_both_axes()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, 640, 480, &w, &h);
+	CHECK(w <= 640);
+	CHECK(h <= 480);
+	CHECK(w >= 1);
+	CHECK(h >= 1);
+}
+
+// C4: only the constrained axis shrinks; the comfortably-fitting axis is
+// passed through unchanged.
+void c4_per_axis()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, 800, 2160, &w, &h);
+	CHECK(w <= 800);
+	CHECK(h == 600);
+}
+
+// C5: a negative work-area dimension is treated as "no constraint" -> unchanged.
+void c5_negative_workarea_unchanged()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, -1, -1, &w, &h);
+	CHECK(w == 820);
+	CHECK(h == 600);
+}
+
+// C6: even a 1x1 work area must never collapse the window to zero.
+void c6_never_zero()
+{
+	int w = 0, h = 0;
+	clamp_default_size(820, 600, 1, 1, &w, &h);
+	CHECK(w >= 1);
+	CHECK(h >= 1);
+}
+
+// C7: shrink-only invariant across a spread of work areas -> the output never
+// exceeds the desired size, which is what makes the change a no-op at 1x.
+void c7_shrink_only_invariant()
+{
+	const int desired_w = 820, desired_h = 600;
+	const int work[][2] = {
+		{ 3840, 2160 }, { 0, 0 }, { 640, 480 }, { 800, 2160 },
+		{ -1, -1 }, { 1, 1 }, { 1024, 768 }, { 820, 600 },
+	};
+	for (const auto& a : work)
+	{
+		int w = 0, h = 0;
+		clamp_default_size(desired_w, desired_h, a[0], a[1], &w, &h);
+		CHECK(w <= desired_w);
+		CHECK(h <= desired_h);
+	}
+}
+
+} // namespace
+
+int main()
+{
+	c1_fits_unchanged();
+	c2_unresolved_monitor_unchanged();
+	c3_oversized_shrinks_both_axes();
+	c4_per_axis();
+	c5_negative_workarea_unchanged();
+	c6_never_zero();
+	c7_shrink_only_invariant();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_window_size_clamp: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_window_size_clamp: ok\n");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- menu background fallback now matches the active theme (light or dark)
- preferences and "What's New" windows no longer open off-screen on HiDPI displays
- audited all hard-coded pixel constants; no scaling bugs found