### PR TITLE
Release v0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .specify/*
 .vscode/*
 .codex
-dev_docs/*
+dev/docs/*
 AGENTS.md
 CLAUDE.md
 

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 MEOW MENU DEVELOPMENT
-0.6.1 (2026-XX-XX)
+0.6.1 (2026-06-05)
 =====
 - Places: fix use-after-free when activating a search result — item is now opened before the menu closes.
 - Places: extend the same lifetime fix to context-menu actions (Open, Open Containing, Open in Terminal, Open With).

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,15 @@
 MEOW MENU DEVELOPMENT
+0.6.1 (2026-XX-XX)
+=====
+- Places: fix use-after-free when activating a search result — item is
+  now opened before the menu closes.
+- Places: extend the same lifetime fix to context-menu actions (Open,
+  Open Containing, Open in Terminal, Open With).
+- Places: open failures now show a single dialog naming the item and
+  including the system error reason; blank/discarded errors are gone.
+- Places: shell-quote paths passed to the external file-manager and
+  terminal helper, fixing names with spaces, quotes, or $(...).
+
 0.6.0 (2026-06-04)
 =====
 - add Top and Bottom sidebar positions with a horizontal scrollable icon strip

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@ MEOW MENU DEVELOPMENT
 - Places: extend the same lifetime fix to context-menu actions (Open, Open Containing, Open in Terminal, Open With).
 - Places: open failures now show a single dialog naming the item and including the system error reason; blank/discarded errors are gone.
 - Places: shell-quote paths passed to the external file-manager and terminal helper, fixing names with spaces, quotes, or $(...).
+- Preset: fresh installs now reliably land on the Modern preset; the old property-count heuristic was fragile and could misdetect a first run as an upgrade on both dev and packaged installs
+- Preset: Properties → General preset field is never blank; when the active layout matches no preset or the identity is unset, the field shows "Custom"
+- Dev: dev-uninstall.sh now clears the plugin's full Xfconf state (including the new /initialized marker) so a reinstall is always detected as a genuine fresh install
+- Dev: development tooling (dev-install.sh, dev-uninstall.sh, and the maintainer notes) is consolidated under dev/
+
 
 0.6.0 (2026-06-04)
 =====

--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ MEOW MENU DEVELOPMENT
 - Preset: Properties → General preset field is never blank; when the active layout matches no preset or the identity is unset, the field shows "Custom"
 - Dev: dev-uninstall.sh now clears the plugin's full Xfconf state (including the new /initialized marker) so a reinstall is always detected as a genuine fresh install
 - Dev: development tooling (dev-install.sh, dev-uninstall.sh, and the maintainer notes) is consolidated under dev/
-
+- Sidebar: fix weird FullScree behaviour when SideBar is off
+- Sidebar: fix sidebar width when it's horizontal in docked style presets
 
 0.6.0 (2026-06-04)
 =====

--- a/NEWS
+++ b/NEWS
@@ -1,14 +1,10 @@
 MEOW MENU DEVELOPMENT
 0.6.1 (2026-XX-XX)
 =====
-- Places: fix use-after-free when activating a search result — item is
-  now opened before the menu closes.
-- Places: extend the same lifetime fix to context-menu actions (Open,
-  Open Containing, Open in Terminal, Open With).
-- Places: open failures now show a single dialog naming the item and
-  including the system error reason; blank/discarded errors are gone.
-- Places: shell-quote paths passed to the external file-manager and
-  terminal helper, fixing names with spaces, quotes, or $(...).
+- Places: fix use-after-free when activating a search result — item is now opened before the menu closes.
+- Places: extend the same lifetime fix to context-menu actions (Open, Open Containing, Open in Terminal, Open With).
+- Places: open failures now show a single dialog naming the item and including the system error reason; blank/discarded errors are gone.
+- Places: shell-quote paths passed to the external file-manager and terminal helper, fixing names with spaces, quotes, or $(...).
 
 0.6.0 (2026-06-04)
 =====

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,10 +57,10 @@ parses this format. Only edit `NEWS` when you are ready to tag.
 ### 3. Build and verify locally
 
 ```bash
-./dev-install.sh
+./dev/dev-install.sh
 ```
 
-> **What `dev-install.sh` does (and does not do)**
+> **What `dev/dev-install.sh` does (and does not do)**
 >
 > This script is a **local development tool only**. It reconfigures Meson
 > (which re-reads `NEWS` and regenerates `panel-plugin/version.h`), compiles,
@@ -73,8 +73,8 @@ parses this format. Only edit `NEWS` when you are ready to tag.
 > need this flag when the master SVG has changed.
 >
 > ```bash
-> ./dev-install.sh --icons   # regenerate icons, then build + reload
-> ./dev-install.sh           # build + reload only (normal case)
+> ./dev/dev-install.sh --icons   # regenerate icons, then build + reload
+> ./dev/dev-install.sh           # build + reload only (normal case)
 > ```
 
 Open the plugin's *About* dialog and confirm the version and date are correct.

--- a/data/presets/classic.meowpreset
+++ b/data/presets/classic.meowpreset
@@ -15,6 +15,7 @@ panel-gap=0
 menu-width=450
 menu-height=500
 launcher-icon-size=2
+category-icon-size=1
 view-mode-default=list
 sidebar-position=right
 sidebar-enabled=true

--- a/data/presets/fullscreen.meowpreset
+++ b/data/presets/fullscreen.meowpreset
@@ -13,6 +13,7 @@ layout-mode=fullscreen
 corner-radius=0
 panel-gap=0
 launcher-icon-size=4
+category-icon-size=1
 view-mode-default=icons
 grid-density=medium
 sidebar-position=left

--- a/data/presets/modern.meowpreset
+++ b/data/presets/modern.meowpreset
@@ -15,6 +15,7 @@ panel-gap=8
 menu-width=450
 menu-height=500
 launcher-icon-size=3
+category-icon-size=1
 view-mode-default=icons
 grid-density=medium
 sidebar-position=left

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,12 @@
+# `dev/` — development tooling
+
+Everything in this folder is for **development purposes only**. None of it ships
+in a package or is required to build, install, or run MeowMenu from a release.
+
+- `dev-install.sh` — build, install, and hot-reload the plugin in a running
+  Xfce session. Run it from the repo root as `./dev/dev-install.sh`.
+- `dev-uninstall.sh` — remove a dev install and reset all stored configuration
+  so the next install is detected as genuinely fresh. Run it as
+  `./dev/dev-uninstall.sh`.
+- `docs/` — maintainer notes (architecture, UX, install/build references). This
+  subfolder is git-ignored; the scripts and this README are tracked.

--- a/dev/dev-install.sh
+++ b/dev/dev-install.sh
@@ -12,7 +12,7 @@
 #   one you just installed under /usr/local.  The script removes that stale copy.
 #
 # USAGE
-#   ./dev-install.sh [--icons] [--reconfigure] [BUILD_DIR]
+#   ./dev/dev-install.sh [--icons] [--reconfigure] [BUILD_DIR]
 #
 #   --icons        Re-render icons/hi*-app-meowmenu.png from build-aux/art/meowmenu.svg
 #                  before building.  Requires rsvg-convert (preferred) or inkscape.
@@ -24,8 +24,9 @@
 #                  Must already exist; run `meson setup build` once first.
 #
 # LOGS
-#   Verbose output from meson and the compiler is redirected to .logs/dev-install.log
-#   (rotated on each run).  Check that file if a step fails.
+#   Verbose output from meson and the compiler is redirected to
+#   dev/.logs/dev-install.log (rotated on each run).  Check that file if a step
+#   fails.
 
 set -euo pipefail
 
@@ -33,8 +34,12 @@ set -euo pipefail
 # Helpers
 # ---------------------------------------------------------------------------
 
-REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-LOG_DIR="${REPO}/.logs"
+# This script lives under dev/; the repo root is its parent. REPO must point at
+# the root so the meson build, build-aux helpers, and icons resolve correctly;
+# logs stay alongside the script under dev/.logs/.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+LOG_DIR="${SCRIPT_DIR}/.logs"
 LOG_FILE="${LOG_DIR}/dev-install.log"
 
 mkdir -p "${LOG_DIR}"

--- a/dev/dev-uninstall.sh
+++ b/dev/dev-uninstall.sh
@@ -16,13 +16,16 @@
 #   itself keeps running with all other plugins intact.
 #
 # USAGE
-#   ./dev-uninstall.sh [BUILD_DIR]
+#   ./dev/dev-uninstall.sh [BUILD_DIR]
 #
-#   BUILD_DIR  Meson build directory (default: ./build).
+#   BUILD_DIR  Meson build directory (default: ./build at the repo root).
 
 set -euo pipefail
 
-REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# This script lives under dev/; the repo root (and its default build dir) is its
+# parent directory.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 BUILD_DIR="${1:-${REPO}/build}"
 
 step() { echo "  » $*"; }
@@ -103,10 +106,38 @@ find "${LOCALEDIR}" -name 'xfce4-meowmenu-plugin.mo' -exec ${NEEDS_SUDO} rm -f {
 step "Remove user presets"
 rm -rf "${HOME}/.local/share/meowmenu/" 2>/dev/null || true
 
+# Legacy on-disk channel file (pre-rename installs); harmless to remove if present.
 XFCONF_FILE="${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/meowmenu.xml"
 if [[ -f "${XFCONF_FILE}" ]]; then
-    step "Reset Xfconf channel (meowmenu.xml)"
+    step "Remove legacy Xfconf channel file (meowmenu.xml)"
     rm -f "${XFCONF_FILE}"
+fi
+
+# The plugin's live settings are NOT in meowmenu.xml: they sit in the
+# xfce4-panel channel under each instance's base (/plugins/plugin-N), including
+# the /initialized first-run marker. Removing only the file would leave xfconfd
+# serving the stale in-memory state, so the next install would be misdetected as
+# an upgrade and land on the wrong preset. Reset the marker and the whole plugin
+# subtree directly through xfconfd so a reinstall is a genuine clean install.
+# NOTE: a targeted --reset --recursive is used deliberately INSTEAD of killing
+# xfconfd, which would race with the panel and corrupt the panel layout.
+if command -v xfconf-query >/dev/null 2>&1; then
+    step "Reset MeowMenu Xfconf state (xfce4-panel channel + /initialized marker)"
+    while IFS= read -r prop; do
+        # Match exactly /plugins/plugin-N (a plugin slot), not its children.
+        if [[ "${prop}" =~ ^/plugins/plugin-[0-9]+$ ]]; then
+            value="$(xfconf-query --channel xfce4-panel --property "${prop}" 2>/dev/null || true)"
+            if [[ "${value}" == "meowmenu" ]]; then
+                step "  Reset ${prop} (recursive)"
+                # Clears every key under the base, marker included, in xfconfd's
+                # in-memory store and on disk.
+                xfconf-query --channel xfce4-panel --property "${prop}" \
+                    --reset --recursive 2>/dev/null || true
+            fi
+        fi
+    done < <(xfconf-query --channel xfce4-panel --list 2>/dev/null || true)
+else
+    step "xfconf-query not found — skipping channel reset (reinstall may not be detected as fresh)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/dev/install.sh
+++ b/dev/install.sh
@@ -173,14 +173,43 @@ fi
 # ---------------------------------------------------------------------------
 # Reset Xfconf state
 # ---------------------------------------------------------------------------
-# Delete the persisted channel XML so the plugin starts from the Modern preset
-# defaults (Settings::migrate_schema sees an empty channel and applies
-# PRESET_MODERN).  Kill xfconfd with SIGKILL *after* the delete so it cannot
-# flush its in-memory state back to disk before dying; D-Bus auto-restarts it.
+# Wipe all MeowMenu state so the next launch behaves like a first install on a
+# clean system: no leftover preset, no /initialized marker, no stale user data.
+#
+# Order matters:
+#   1. Remove user presets from ~/.local/share/meowmenu/.
+#   2. Reset xfce4-panel channel entries for every meowmenu slot via
+#      xfconf-query while xfconfd is alive — this writes the cleaned state to
+#      xfce4-panel.xml on disk before xfconfd is stopped.
+#   3. Delete meowmenu.xml (the plugin's own channel file).
+#   4. Kill xfconfd with SIGKILL so it cannot flush any remaining in-memory
+#      state back to disk; D-Bus auto-restarts it against the clean files.
+
+step "Remove user presets"
+rm -rf "${HOME}/.local/share/meowmenu/" 2>/dev/null || true
+
+if command -v xfconf-query >/dev/null 2>&1; then
+    step "Reset MeowMenu Xfconf state (xfce4-panel channel + /initialized marker)"
+    while IFS= read -r prop; do
+        # Match exactly /plugins/plugin-N (a plugin slot), not its children.
+        if [[ "${prop}" =~ ^/plugins/plugin-[0-9]+$ ]]; then
+            value="$(xfconf-query --channel xfce4-panel --property "${prop}" 2>/dev/null || true)"
+            if [[ "${value}" == "meowmenu" ]]; then
+                step "  Reset ${prop} (recursive)"
+                # Clears every key under the base, the preset and /initialized
+                # marker included, in xfconfd's in-memory store and on disk.
+                xfconf-query --channel xfce4-panel --property "${prop}" \
+                    --reset --recursive 2>/dev/null || true
+            fi
+        fi
+    done < <(xfconf-query --channel xfce4-panel --list 2>/dev/null || true)
+else
+    step "xfconf-query not found — skipping channel reset (reinstall may not be detected as fresh)"
+fi
 
 XFCONF_FILE="${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/meowmenu.xml"
 if [[ -f "${XFCONF_FILE}" ]]; then
-    step "Reset Xfconf channel (meowmenu.xml)"
+    step "Remove Xfconf channel file (meowmenu.xml)"
     rm -f "${XFCONF_FILE}"
 fi
 pkill -9 xfconfd 2>/dev/null || true

--- a/dev/uninstall.sh
+++ b/dev/uninstall.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# dev-uninstall.sh — remove a MeowMenu dev install and wipe all user config.
+# dev-uninstall.sh — remove a MeowMenu dev install and wipe every trace of
+#                    user configuration, leaving the system as if MeowMenu had
+#                    never been installed.
 #
 # BACKGROUND
 #   Use this before creating a release branch or PR to verify you are starting
-#   from a clean slate — no installed files, no leftover Xfconf state.
-#   It is the counterpart of dev-install.sh; both are dev/debug helpers and are
-#   not part of the public install documentation.
+#   from a clean slate — no installed files, no leftover Xfconf state, no user
+#   presets, no /initialized marker.  It is the counterpart of dev-install.sh;
+#   both are dev/debug helpers and are not part of the public install
+#   documentation.
 #
 #   The script reads the install prefix from the build directory so it removes
 #   exactly what dev-install.sh put there.  If the build directory is missing

--- a/panel-plugin/core/sidebar-layout.cpp
+++ b/panel-plugin/core/sidebar-layout.cpp
@@ -90,14 +90,34 @@ SwitchPresentation meow_compute_sidebar_layout(const SidebarLayoutState& state)
 
 StripGeometry meow_compute_strip_geometry(SidebarPosition position, bool ltr)
 {
-	(void)ltr; // vertical order is direction-independent for a horizontal strip
+	(void)ltr; // order is direction-independent; anchors are direction-relative
 	StripGeometry out;
 	out.order = (position == SidebarPosition::Bottom)
 			? StripOrder::StripBelowResults
 			: StripOrder::StripAboveResults;
-	out.centred = true;
+	// Single-row anchoring: toggle pinned leading, categories pinned trailing,
+	// with the slack between them. Leading/Trailing map to GTK START/END, so the
+	// physical side follows the text direction without a branch here.
+	out.toggle_anchor = StripAnchor::Leading;
+	out.categories_anchor = StripAnchor::Trailing;
 	out.width_from_search_box = true;
 	return out;
+}
+
+int meow_toggle_icon_px(SwitchLocation location, int category_px, int search_bar_px)
+{
+	// The toggle inherits the pixel size of the region that contains it; a
+	// hidden toggle (None) gets no size, signalled by 0.
+	switch (location)
+	{
+	case SwitchLocation::InSidebar:
+		return category_px;
+	case SwitchLocation::InSearchBar:
+		return search_bar_px;
+	case SwitchLocation::None:
+	default:
+		return 0;
+	}
 }
 
 bool meow_category_label_visible(bool category_show_name, bool horizontal)

--- a/panel-plugin/core/sidebar-layout.h
+++ b/panel-plugin/core/sidebar-layout.h
@@ -112,34 +112,64 @@ enum class StripOrder
 	StripBelowResults    // strip is rendered below the results box (Bottom)
 };
 
+// Direction-relative anchoring of a group within the horizontal strip. Leading
+// maps to GTK START and Trailing to GTK END, so RTL is handled for free: the
+// leading edge is the left in LTR and the right in RTL.
+enum class StripAnchor
+{
+	Leading,
+	Trailing
+};
+
 /* StripGeometry:
  *
  * The render-time geometry of a docked Top/Bottom category strip: where it sits
- * relative to the results box, that it is horizontally centred, and that its
- * width tracks the search box. centred / width_from_search_box are invariants
- * (always true) — they are surfaced so the unit test pins them against drift.
+ * relative to the results box, where its two groups anchor on the single row,
+ * and that its width tracks the search box. The Apps/Places toggle anchors to
+ * the leading edge and the category-icon group to the trailing edge, with the
+ * slack between them; width_from_search_box is an invariant (always true). The
+ * fields are surfaced so the unit test pins them against drift.
  */
 struct StripGeometry
 {
 	StripOrder order;
-	bool centred;                 // always true — strip is horizontally centred
-	bool width_from_search_box;   // always true — width source is the search box
+	StripAnchor toggle_anchor;      // always Leading — toggle pinned to the row's leading edge
+	StripAnchor categories_anchor;  // always Trailing — categories pinned to the trailing edge
+	bool width_from_search_box;     // always true — width source is the search box
 };
 
 /* meow_compute_strip_geometry:
  * @position: the stored sidebar position (only Top/Bottom produce a strip).
  * @ltr: text direction; passed for completeness — the vertical strip order is
- *       direction-independent (a Top strip is above the results in LTR and RTL).
+ *       direction-independent (a Top strip is above the results in LTR and RTL),
+ *       and the leading/trailing anchors are themselves direction-relative.
  *
- * Pure decision for a Top/Bottom strip's stacking order and width source. Top
- * places the strip above the results box (it sits below the search bar); Bottom
- * places it below the results box. Left/Right are not strips and default to the
- * Top arrangement (the caller does not render a strip for them).
+ * Pure decision for a Top/Bottom strip's stacking order, row anchoring, and
+ * width source. Top places the strip above the results box (it sits below the
+ * search bar); Bottom places it below the results box. Left/Right are not strips
+ * and default to the Top arrangement (the caller does not render a strip for
+ * them).
  *
- * Returns: the resolved StripGeometry; centred and width_from_search_box are
- * always true.
+ * Returns: the resolved StripGeometry; toggle_anchor is always Leading,
+ * categories_anchor always Trailing, and width_from_search_box always true.
  */
 StripGeometry meow_compute_strip_geometry(SidebarPosition position, bool ltr);
+
+/* meow_toggle_icon_px:
+ * @location: where the Apps/Places toggle is rendered this pass.
+ * @category_px: the configured category icon pixel size (sidebar source).
+ * @search_bar_px: the measured search-bar-height-derived pixel size.
+ *
+ * Pure decision for the toggle icon's pixel size: the toggle always inherits
+ * from the region that contains it — the category icon size when it lives in a
+ * sidebar (vertical or strip), the search-bar height when it lives in the
+ * search-bar row. There is deliberately no independent value and no fourth
+ * state.
+ *
+ * Returns: the pixel size to apply with gtk_image_set_pixel_size(); 0 when the
+ * toggle is hidden (SwitchLocation::None), meaning no size is applied.
+ */
+int meow_toggle_icon_px(SwitchLocation location, int category_px, int search_bar_px);
 
 /* meow_category_label_visible:
  * @category_show_name: the stored "show category names" intent.

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -184,13 +184,13 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 	m_category_width_group(nullptr),
 	m_sidebar_size_group(nullptr),
 	m_mode_button_size_group(nullptr),
-	m_strip_width_group(nullptr),
 	m_geometry{0,0,1,1},
 	m_layout_ltr(true),
 	m_layout_categories_horizontal(false),
 	m_layout_sidebar_enabled(true),
 	m_layout_switch_show_icons(false),
 	m_layout_category_show_name(true),
+	m_layout_category_icon_size(-2),
 	m_layout_categories_alternate(false),
 	m_layout_search_alternate(false),
 	m_layout_commands_alternate(false),
@@ -1175,11 +1175,16 @@ void WhiskerMenu::Window::show(const Position position)
 	const bool sidebar_enabled = m_settings->sidebar_enabled;
 	const bool switch_show_icons = m_settings->places_switch_show_icons;
 	const bool category_show_name = m_settings->category_show_name;
+	// The Apps/Places toggle inherits the category icon size when it lives in a
+	// sidebar, so a live category-icon-size edit must re-run update_layout() to
+	// resize the toggle (the category buttons reload unconditionally below).
+	const int category_icon_size = m_settings->category_icon_size;
 	if ((m_layout_ltr != layout_ltr)
 			|| (m_layout_categories_horizontal != cats_horizontal)
 			|| (m_layout_sidebar_enabled != sidebar_enabled)
 			|| (m_layout_switch_show_icons != switch_show_icons)
 			|| (m_layout_category_show_name != category_show_name)
+			|| (m_layout_category_icon_size != category_icon_size)
 			|| (m_layout_categories_alternate != cats_alt)
 			|| (m_layout_search_alternate != search_alt)
 			|| (m_layout_commands_alternate != commands_alt)
@@ -1192,6 +1197,7 @@ void WhiskerMenu::Window::show(const Position position)
 		m_layout_sidebar_enabled = sidebar_enabled;
 		m_layout_switch_show_icons = switch_show_icons;
 		m_layout_category_show_name = category_show_name;
+		m_layout_category_icon_size = category_icon_size;
 		m_layout_categories_alternate = cats_alt;
 		m_layout_search_alternate = search_alt;
 		m_layout_commands_alternate = commands_alt;
@@ -1215,18 +1221,27 @@ void WhiskerMenu::Window::show(const Position position)
 	// than their configured menu-width when switching back from FullScreen.
 	if (is_fullscreen)
 	{
-		// Center search bar at 50% of screen width (issue #3)
-		gtk_widget_set_halign(GTK_WIDGET(m_search_box), GTK_ALIGN_CENTER);
-		gtk_widget_set_size_request(GTK_WIDGET(m_search_box), m_workarea.width / 2, -1);
-		// Full-screen strip parity (FR-010/011): the horizontal category strip is
-		// anchored to the search-bar column, not the screen. m_strip_width_group
-		// already ties m_categories_box to m_search_box (== workarea/2, centred),
-		// so centre it like the search box; its outer margins then match the search
-		// bar's by construction. The leading/trailing in-column anchoring is set
-		// structurally in update_layout() — only the column alignment differs by
-		// mode, and setting it here (every relayout) keeps it correct across
-		// docked↔full-screen toggles (FR-014).
-		gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_CENTER);
+		// Centre the search bar in a fixed half-width column (issue #3). FILL plus
+		// symmetric side margins pin the column to exactly workarea/2 regardless
+		// of the search entry's natural width or whether the Apps/Places switch
+		// shares the row, so entry + switch together never grow past the width the
+		// entry alone occupies with Places off. A bare halign CENTER would instead
+		// grow to the children's natural width and let the switch widen the row.
+		const int column_width  = m_workarea.width / 2;
+		const int column_margin = (m_workarea.width - column_width) / 2;
+		gtk_widget_set_halign(GTK_WIDGET(m_search_box), GTK_ALIGN_FILL);
+		gtk_widget_set_size_request(GTK_WIDGET(m_search_box), -1, -1);
+		gtk_widget_set_margin_start(GTK_WIDGET(m_search_box), column_margin);
+		gtk_widget_set_margin_end(GTK_WIDGET(m_search_box), column_margin);
+		// Full-screen strip parity (FR-010/011/019/020): the Top/Bottom category
+		// strip shares that exact column. Identical FILL + margins put the leading
+		// toggle on the search bar's left edge and the trailing category icons on
+		// its right edge, with the slack between them. Set on every relayout so
+		// docked↔full-screen and orientation flips reflow with no stale margins
+		// (FR-014).
+		gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
+		gtk_widget_set_margin_start(GTK_WIDGET(m_categories_box), column_margin);
+		gtk_widget_set_margin_end(GTK_WIDGET(m_categories_box), column_margin);
 		// Keep sidebar width meaningful, and compensate on the opposite side so
 		// the applications grid stays centered.
 		// NOTE (FR-026/027): the symmetry margin is a fixed fraction of the work
@@ -1258,12 +1273,16 @@ void WhiskerMenu::Window::show(const Position position)
 	{
 		gtk_widget_set_halign(GTK_WIDGET(m_search_box), GTK_ALIGN_FILL);
 		gtk_widget_set_size_request(GTK_WIDGET(m_search_box), -1, -1);
+		gtk_widget_set_margin_start(GTK_WIDGET(m_search_box), 0);
+		gtk_widget_set_margin_end(GTK_WIDGET(m_search_box), 0);
 		gtk_widget_set_size_request(GTK_WIDGET(m_sidebar), -1, -1);
 		gtk_widget_set_margin_start(GTK_WIDGET(m_panels_stack), 0);
 		gtk_widget_set_margin_end(GTK_WIDGET(m_panels_stack), 0);
 		// Docked: the strip fills the menu width so the toggle reaches the leading
 		// edge and the categories the trailing edge of the menu (FR-005/008).
 		gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
+		gtk_widget_set_margin_start(GTK_WIDGET(m_categories_box), 0);
+		gtk_widget_set_margin_end(GTK_WIDGET(m_categories_box), 0);
 	}
 
 	update_background_css();
@@ -2427,15 +2446,10 @@ void WhiskerMenu::Window::update_layout()
 			gtk_box_reorder_child(m_category_buttons, m_strip_lead_spacer, 0);
 			gtk_widget_show(m_strip_lead_spacer);
 			gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
-			// Tie the strip width to the search box (FR-019/020): a shared
-			// horizontal size group keeps strip == search-box width without
-			// re-deriving the workarea/2 figure used in fullscreen.
-			if (!m_strip_width_group)
-			{
-				m_strip_width_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
-				gtk_size_group_add_widget(m_strip_width_group, GTK_WIDGET(m_search_box));
-				gtk_size_group_add_widget(m_strip_width_group, GTK_WIDGET(m_categories_box));
-			}
+			// The strip's column width and its edge alignment with the search bar
+			// in full-screen are owned by the FILL + symmetric-margin geometry
+			// applied in show() (docked = menu width, full-screen = workarea/2),
+			// so no size group is needed to track the search box (FR-019/020).
 			// Reveal the scroller/viewport without gtk_widget_show_all, which
 			// would override the per-button visibility set above.
 			gtk_widget_show(GTK_WIDGET(m_strip_scroll));
@@ -2471,7 +2485,6 @@ void WhiskerMenu::Window::update_layout()
 		GtkWidget* sw = GTK_WIDGET(m_mode_selector_box);
 		GtkWidget* cur = gtk_widget_get_parent(sw);
 		GtkWidget* target = nullptr;
-		bool pack_end_target = false;
 		switch (pres.switch_location)
 		{
 		case SwitchLocation::InSidebar:
@@ -2487,10 +2500,11 @@ void WhiskerMenu::Window::update_layout()
 			                     : GTK_WIDGET(m_category_buttons);
 			break;
 		case SwitchLocation::InSearchBar:
-			// Sidebar disabled: trailing end of whichever row hosts the search
-			// entry — m_title_box in unified-bar mode, else m_search_box (R1).
+			// Sidebar disabled: the switch joins whichever row hosts the search
+			// entry — m_title_box in unified-bar mode, else m_search_box (R1) — and
+			// is placed just before the command buttons (see below) so the commands
+			// keep their trailing position and the entry yields the room (FR-019).
 			target = unified_now ? GTK_WIDGET(m_title_box) : GTK_WIDGET(m_search_box);
-			pack_end_target = true;
 			break;
 		case SwitchLocation::None:
 		default:
@@ -2502,14 +2516,31 @@ void WhiskerMenu::Window::update_layout()
 			g_object_ref(sw);
 			if (cur)
 				gtk_container_remove(GTK_CONTAINER(cur), sw);
-			if (pack_end_target)
+			if (pres.switch_location == SwitchLocation::InSearchBar)
 			{
-				// Two small theme gaps: entry↔switch (this spacing) and
-				// switch↔edge (the row's own end padding) (FR-019).
-				gtk_box_pack_end(GTK_BOX(target), sw, false, false, 6);
+				// Insert the switch directly before the command buttons in the
+				// search row, not at the very trailing edge: the commands stay
+				// rightmost and the search entry shrinks to make room (FR-019). In
+				// full-screen the row is a fixed half-width column, so entry +
+				// switch never exceed the entry's width with Places off. When no
+				// commands share the row, the switch becomes the trailing element.
+				gtk_box_pack_start(GTK_BOX(target), sw, false, false, 0);
+				GtkWidget* cmd = GTK_WIDGET(m_commands_box);
+				if (gtk_widget_get_parent(cmd) == target)
+				{
+					GList* kids = gtk_container_get_children(GTK_CONTAINER(target));
+					gtk_box_reorder_child(GTK_BOX(target), sw,
+							g_list_index(kids, cmd));
+					g_list_free(kids);
+				}
+				else
+				{
+					gtk_box_reorder_child(GTK_BOX(target), sw, -1);
+				}
 			}
 			else
 			{
+				// Strip / vertical sidebar: the toggle anchors leading (child 0).
 				gtk_box_pack_start(GTK_BOX(target), sw, false, false, 0);
 				gtk_box_reorder_child(GTK_BOX(target), sw, 0);
 			}

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -178,6 +178,7 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 	m_places_property_slot(0),
 	m_mode_selector_separator(nullptr),
 	m_strip_scroll(nullptr),
+	m_strip_lead_spacer(nullptr),
 	m_sidebar_struct(1),
 	m_switch_loc(SwitchLocation::InSidebar),
 	m_category_width_group(nullptr),
@@ -1217,6 +1218,15 @@ void WhiskerMenu::Window::show(const Position position)
 		// Center search bar at 50% of screen width (issue #3)
 		gtk_widget_set_halign(GTK_WIDGET(m_search_box), GTK_ALIGN_CENTER);
 		gtk_widget_set_size_request(GTK_WIDGET(m_search_box), m_workarea.width / 2, -1);
+		// Full-screen strip parity (FR-010/011): the horizontal category strip is
+		// anchored to the search-bar column, not the screen. m_strip_width_group
+		// already ties m_categories_box to m_search_box (== workarea/2, centred),
+		// so centre it like the search box; its outer margins then match the search
+		// bar's by construction. The leading/trailing in-column anchoring is set
+		// structurally in update_layout() — only the column alignment differs by
+		// mode, and setting it here (every relayout) keeps it correct across
+		// docked↔full-screen toggles (FR-014).
+		gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_CENTER);
 		// Keep sidebar width meaningful, and compensate on the opposite side so
 		// the applications grid stays centered.
 		// NOTE (FR-026/027): the symmetry margin is a fixed fraction of the work
@@ -1251,6 +1261,9 @@ void WhiskerMenu::Window::show(const Position position)
 		gtk_widget_set_size_request(GTK_WIDGET(m_sidebar), -1, -1);
 		gtk_widget_set_margin_start(GTK_WIDGET(m_panels_stack), 0);
 		gtk_widget_set_margin_end(GTK_WIDGET(m_panels_stack), 0);
+		// Docked: the strip fills the menu width so the toggle reaches the leading
+		// edge and the categories the trailing edge of the menu (FR-005/008).
+		gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
 	}
 
 	update_background_css();
@@ -2141,7 +2154,7 @@ void WhiskerMenu::Window::move_window()
 
 void WhiskerMenu::Window::set_mode_button_content(GtkToggleButton* button,
 		bool show_icons, const char* const* icon_chain, const char* short_label,
-		const char* long_label)
+		const char* long_label, int icon_px)
 {
 	GtkWidget* child = gtk_bin_get_child(GTK_BIN(button));
 
@@ -2155,15 +2168,30 @@ void WhiskerMenu::Window::set_mode_button_content(GtkToggleButton* button,
 
 	if (show_icons)
 	{
-		if (GTK_IS_IMAGE(child))
-			return;
 		GtkIconTheme* theme = gtk_icon_theme_get_default();
 		const char* name = meow_resolve_icon_name(theme, icon_chain);
-		GtkWidget* image = gtk_image_new_from_icon_name(name, GTK_ICON_SIZE_BUTTON);
-		if (child)
-			gtk_container_remove(GTK_CONTAINER(button), child);
-		gtk_container_add(GTK_CONTAINER(button), image);
-		gtk_widget_show(image);
+		// Reuse an existing image child so a relayout that only changes the
+		// derived size (e.g. category-icon-size edited) refreshes the pixel size
+		// in place rather than no-op'ing on the early child check (FR-002).
+		GtkImage* image;
+		if (GTK_IS_IMAGE(child))
+		{
+			image = GTK_IMAGE(child);
+			gtk_image_set_from_icon_name(image, name, GTK_ICON_SIZE_BUTTON);
+		}
+		else
+		{
+			image = GTK_IMAGE(gtk_image_new_from_icon_name(name, GTK_ICON_SIZE_BUTTON));
+			if (child)
+				gtk_container_remove(GTK_CONTAINER(button), child);
+			gtk_container_add(GTK_CONTAINER(button), GTK_WIDGET(image));
+			gtk_widget_show(GTK_WIDGET(image));
+		}
+		// Size the toggle icon from its containing region (FR-001/002/003): the
+		// category icon size in a sidebar, the search-bar height in the search
+		// row. icon_px <= 0 means the toggle is hidden, so keep the themed size.
+		if (icon_px > 0)
+			gtk_image_set_pixel_size(image, icon_px);
 	}
 	else
 	{
@@ -2188,13 +2216,30 @@ void WhiskerMenu::Window::apply_switch_presentation(const SwitchPresentation& pr
 {
 	const bool icons = pres.effective_show_icons;
 
+	// Resolve the toggle icon size from its region (FR-001/003/012/013). The
+	// sidebar source is the authoritative category icon size; the search-bar
+	// source has no stored value, so it is measured live from the search entry.
+	const int category_px = m_settings->category_icon_size.get_size();
+
+	// NOTE: the search-bar height is not stored anywhere; the search entry's
+	// natural height is the only authoritative measure. Reduce it by a small
+	// fixed inset so the icon sits inside the control rather than touching its
+	// edges, and clamp to the icon-size ladder's sane range (16..128 px).
+	int search_entry_h = 0;
+	gtk_widget_get_preferred_height(GTK_WIDGET(m_search_entry), nullptr, &search_entry_h);
+	const int SEARCH_BAR_ICON_INSET = 8;
+	const int search_bar_px = CLAMP(search_entry_h - SEARCH_BAR_ICON_INSET, 16, 128);
+
+	const int icon_px =
+			meow_toggle_icon_px(pres.switch_location, category_px, search_bar_px);
+
 	// Text↔icon child swap (FR-012/014): the visible text label is the short
 	// "Apps"/"Places"; the long "Applications"/"Places" stays as tooltip and
 	// accessible name in both modes.
 	set_mode_button_content(m_mode_btn_apps, icons, MEOW_SWITCH_APPS_ICONS,
-			_("Apps"), _("Applications"));
+			_("Apps"), _("Applications"), icon_px);
 	set_mode_button_content(m_mode_btn_places, icons, MEOW_SWITCH_PLACES_ICONS,
-			_("Places"), _("Places"));
+			_("Places"), _("Places"), icon_px);
 
 	// Switch-box orientation (FR-007/008/014): vertical only on a vertical
 	// sidebar with category names hidden; horizontal everywhere else.
@@ -2350,17 +2395,41 @@ void WhiskerMenu::Window::update_layout()
 				gtk_scrolled_window_set_policy(m_strip_scroll,
 						GTK_POLICY_AUTOMATIC, GTK_POLICY_NEVER);
 				gtk_scrolled_window_set_overlay_scrolling(m_strip_scroll, TRUE);
-				// Don't let an icon-heavy strip widen the menu: the scroller
-				// requests a minimal natural width and scrolls overflow within
-				// the search-box-matched width set by the size group (FR-020).
+				// NOTE: the spurious scrollbar was a symptom of the old centred
+				// collapse, not real overflow; the fix is the width source (the
+				// FILL row below), not the policy. AUTOMATIC is retained so a
+				// genuinely icon-heavy strip still scrolls (many-categories edge
+				// case); propagate_natural_width stays FALSE so the strip can never
+				// widen the menu — it scrolls within the search-box-matched width
+				// instead (FR-008/009).
 				gtk_scrolled_window_set_propagate_natural_width(m_strip_scroll, FALSE);
 				gtk_box_pack_start(m_categories_box, GTK_WIDGET(m_strip_scroll), true, true, 0);
 			}
+			if (!m_strip_lead_spacer)
+			{
+				// Leading expander that pushes the category icons to the trailing
+				// edge inside the (stretched) viewport, so the slack falls between
+				// the leading toggle and the trailing icons (FR-005). A GtkViewport
+				// stretches its child to the view width and ignores child halign,
+				// so the trailing pull must come from an expanding child rather than
+				// an alignment.
+				m_strip_lead_spacer = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+				gtk_widget_set_hexpand(m_strip_lead_spacer, TRUE);
+				gtk_box_pack_start(m_category_buttons, m_strip_lead_spacer, true, true, 0);
+			}
 			scroller_add_child(m_strip_scroll, GTK_WIDGET(m_category_buttons));
-			// Centre the strip and tie its width to the search box (FR-019/020).
-			// A shared horizontal size group keeps the strip == search-box width
-			// without re-deriving the workarea/2 figure used in fullscreen.
-			gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_CENTER);
+			// Single row: toggle flush-leading, categories flush-trailing
+			// (StripGeometry toggle_anchor/categories_anchor). The categories box
+			// fills the available width (docked = menu width); the fullscreen pass
+			// in show() overrides to CENTER so the strip tracks the search-box
+			// column. The switch is pinned leading by the re-homing block below;
+			// this spacer pins the icons trailing.
+			gtk_box_reorder_child(m_category_buttons, m_strip_lead_spacer, 0);
+			gtk_widget_show(m_strip_lead_spacer);
+			gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
+			// Tie the strip width to the search box (FR-019/020): a shared
+			// horizontal size group keeps strip == search-box width without
+			// re-deriving the workarea/2 figure used in fullscreen.
 			if (!m_strip_width_group)
 			{
 				m_strip_width_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
@@ -2382,11 +2451,15 @@ void WhiskerMenu::Window::update_layout()
 			// scroller either way; the sidebar itself is shown only when enabled.
 			gtk_orientable_set_orientation(GTK_ORIENTABLE(m_category_buttons),
 					GTK_ORIENTATION_VERTICAL);
+			// The strip-only trailing spacer must not consume space in the
+			// vertical sidebar list; hiding it removes it from allocation entirely.
+			if (m_strip_lead_spacer)
+				gtk_widget_hide(m_strip_lead_spacer);
 			scroller_add_child(m_sidebar, GTK_WIDGET(m_category_buttons));
 			gtk_widget_set_visible(GTK_WIDGET(m_categories_box), false);
 			gtk_widget_set_visible(GTK_WIDGET(m_sidebar), want_vertical);
-			// No strip in this structure: drop the centred-strip alignment so
-			// the (hidden) container imposes nothing on its size group.
+			// No strip in this structure: drop the strip alignment so the (hidden)
+			// container imposes nothing on its size group.
 			gtk_widget_set_halign(GTK_WIDGET(m_categories_box), GTK_ALIGN_FILL);
 		}
 		g_object_unref(m_category_buttons);
@@ -2402,8 +2475,14 @@ void WhiskerMenu::Window::update_layout()
 		switch (pres.switch_location)
 		{
 		case SwitchLocation::InSidebar:
-			// Strip: pinned leading in m_categories_box, outside the scroller
-			// (FR-014). Vertical sidebar: first child of the button list.
+			// Strip: the toggle anchors to the row's leading edge
+			// (StripGeometry.toggle_anchor == Leading). It is pack_start'd +
+			// reordered to child 0 in m_categories_box, outside the scroller
+			// (FR-006/014); pack_start is direction-aware, so it follows
+			// m_layout_ltr (leading = left in LTR, right in RTL) for free, and the
+			// trailing category icons stay pinned by m_strip_lead_spacer. When the
+			// toggle is absent (None) this leading anchor is simply left empty
+			// (FR-007). Vertical sidebar: first child of the button list.
 			target = want_strip ? GTK_WIDGET(m_categories_box)
 			                     : GTK_WIDGET(m_category_buttons);
 			break;

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -652,6 +652,16 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 	gtk_box_pack_start(m_vbox, GTK_WIDGET(m_search_box), false, true, 0);
 	gtk_box_pack_start(m_search_box, GTK_WIDGET(m_search_entry), true, true, 0);
 
+	// Unified-bar centring cluster (full-screen only). In unified-bar mode the
+	// search entry and the Apps/Places switch must travel together as one
+	// centred unit (switch trailing the entry), so they live in this box and the
+	// box — not the bare entry — becomes m_title_box's centre widget. A fixed
+	// width on the cluster makes the entry yield room to the switch instead of
+	// the row growing. We hold an owning ref because the cluster is unparented in
+	// every non-unified layout; it is released in the destructor.
+	m_search_cluster = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+	g_object_ref_sink(m_search_cluster);
+
 	// Three void bands for FullScreen unified-bar mode (FR-008, FR-017, FR-018).
 	// All three are hidden until update_layout() activates the unified bar.
 	// Fixed size_request heights give breathing room; theme authors can override
@@ -925,6 +935,12 @@ WhiskerMenu::Window::~Window()
 	{
 		g_object_unref(m_category_width_group);
 		m_category_width_group = nullptr;
+	}
+
+	if (m_search_cluster)
+	{
+		g_object_unref(m_search_cluster);
+		m_search_cluster = nullptr;
 	}
 
 	if (m_css_provider)
@@ -1253,20 +1269,24 @@ void WhiskerMenu::Window::show(const Position position)
 		const int sidebar_width = m_workarea.width / 6;
 		const bool sidebar_on_left = (m_layout_ltr == m_layout_categories_alternate);
 		gtk_widget_set_size_request(GTK_WIDGET(m_sidebar), sidebar_width, -1);
-		// With a Top/Bottom strip the vertical sidebar is hidden, so a one-sided
-		// margin would shove the results box off-centre. Mirror the margin on
-		// both sides to keep the results box centred with the same symmetric
-		// empty space (FR-023/SC-007); the strip spans only the centred
-		// search-box-width column above/below it, never the full workarea.
-		if (cats_horizontal)
-		{
-			gtk_widget_set_margin_start(GTK_WIDGET(m_panels_stack), sidebar_width);
-			gtk_widget_set_margin_end(GTK_WIDGET(m_panels_stack), sidebar_width);
-		}
-		else
+		// The one-sided compensating margin is correct *only* when a vertical
+		// sidebar actually occupies one side. The sidebar is shown only when it is
+		// enabled and not laid out as a Top/Bottom strip; in every other case
+		// (sidebar disabled, or a horizontal strip) no widget fills that side, so a
+		// one-sided margin would shove the results box off-centre — exactly the
+		// "no void on the left" symptom. Mirror the margin on both sides there to
+		// keep the grid centred with symmetric voids, aligned with the centred
+		// search bar (FR-023/SC-007).
+		const bool vertical_sidebar_visible = sidebar_enabled && !cats_horizontal;
+		if (vertical_sidebar_visible)
 		{
 			gtk_widget_set_margin_start(GTK_WIDGET(m_panels_stack), sidebar_on_left ? 0 : sidebar_width);
 			gtk_widget_set_margin_end(GTK_WIDGET(m_panels_stack), sidebar_on_left ? sidebar_width : 0);
+		}
+		else
+		{
+			gtk_widget_set_margin_start(GTK_WIDGET(m_panels_stack), sidebar_width);
+			gtk_widget_set_margin_end(GTK_WIDGET(m_panels_stack), sidebar_width);
 		}
 	}
 	else
@@ -2500,11 +2520,12 @@ void WhiskerMenu::Window::update_layout()
 			                     : GTK_WIDGET(m_category_buttons);
 			break;
 		case SwitchLocation::InSearchBar:
-			// Sidebar disabled: the switch joins whichever row hosts the search
-			// entry — m_title_box in unified-bar mode, else m_search_box (R1) — and
-			// is placed just before the command buttons (see below) so the commands
+			// Sidebar disabled: the switch joins the search entry. In unified-bar
+			// mode that means the centring cluster (so [entry][switch] stays
+			// centred as one unit); otherwise the plain search row, where it is
+			// placed just before the command buttons (see below) so the commands
 			// keep their trailing position and the entry yields the room (FR-019).
-			target = unified_now ? GTK_WIDGET(m_title_box) : GTK_WIDGET(m_search_box);
+			target = unified_now ? m_search_cluster : GTK_WIDGET(m_search_box);
 			break;
 		case SwitchLocation::None:
 		default:
@@ -2516,14 +2537,24 @@ void WhiskerMenu::Window::update_layout()
 			g_object_ref(sw);
 			if (cur)
 				gtk_container_remove(GTK_CONTAINER(cur), sw);
-			if (pres.switch_location == SwitchLocation::InSearchBar)
+			if (pres.switch_location == SwitchLocation::InSearchBar
+					&& target == m_search_cluster)
 			{
-				// Insert the switch directly before the command buttons in the
-				// search row, not at the very trailing edge: the commands stay
-				// rightmost and the search entry shrinks to make room (FR-019). In
-				// full-screen the row is a fixed half-width column, so entry +
-				// switch never exceed the entry's width with Places off. When no
-				// commands share the row, the switch becomes the trailing element.
+				// Unified bar: the switch trails the search entry inside the
+				// centring cluster, so [entry][switch] stay centred as one unit and
+				// the entry shrinks to leave room rather than the row growing
+				// (FR-019). The entry is reordered to child 0 in the unified-bar
+				// transition below, so reorder the switch to last here.
+				gtk_box_pack_start(GTK_BOX(target), sw, false, false, 0);
+				gtk_box_reorder_child(GTK_BOX(target), sw, -1);
+			}
+			else if (pres.switch_location == SwitchLocation::InSearchBar)
+			{
+				// Plain (non-unified) search row: insert the switch directly before
+				// the command buttons, not at the very trailing edge, so the
+				// commands stay rightmost and the search entry shrinks to make room
+				// (FR-019). When no commands share the row, the switch becomes the
+				// trailing element.
 				gtk_box_pack_start(GTK_BOX(target), sw, false, false, 0);
 				GtkWidget* cmd = GTK_WIDGET(m_commands_box);
 				if (gtk_widget_get_parent(cmd) == target)
@@ -2766,11 +2797,18 @@ void WhiskerMenu::Window::update_layout()
 	{
 		g_object_ref(m_search_entry);
 		gtk_container_remove(GTK_CONTAINER(m_search_box), GTK_WIDGET(m_search_entry));
-		gtk_widget_set_hexpand(GTK_WIDGET(m_search_entry), FALSE);
+		// The entry hexpands inside the cluster: the cluster has a fixed width
+		// (set below), so the entry fills whatever the trailing switch leaves.
+		gtk_widget_set_hexpand(GTK_WIDGET(m_search_entry), TRUE);
 		gtk_widget_set_halign(GTK_WIDGET(m_search_entry), GTK_ALIGN_FILL);
 		gtk_widget_set_margin_start(GTK_WIDGET(m_search_entry), 0);
 		gtk_widget_set_margin_end(GTK_WIDGET(m_search_entry), 0);
-		gtk_box_set_center_widget(m_title_box, GTK_WIDGET(m_search_entry));
+		gtk_box_pack_start(GTK_BOX(m_search_cluster), GTK_WIDGET(m_search_entry), TRUE, TRUE, 0);
+		// Entry leads, switch (if any) trails: the re-homing block above may have
+		// already parked the switch in the cluster, so pin the entry to child 0.
+		gtk_box_reorder_child(GTK_BOX(m_search_cluster), GTK_WIDGET(m_search_entry), 0);
+		gtk_widget_set_visible(m_search_cluster, TRUE);
+		gtk_box_set_center_widget(m_title_box, m_search_cluster);
 		gtk_widget_set_visible(GTK_WIDGET(m_search_box), FALSE);
 		gtk_style_context_add_class(title_ctx, "unified-bar");
 		g_object_unref(m_search_entry);
@@ -2779,6 +2817,10 @@ void WhiskerMenu::Window::update_layout()
 	{
 		g_object_ref(m_search_entry);
 		gtk_box_set_center_widget(m_title_box, nullptr);
+		// The entry now lives in the cluster (the switch, if it was there, has
+		// already been re-homed to m_search_box by the block above on this pass).
+		gtk_container_remove(GTK_CONTAINER(m_search_cluster), GTK_WIDGET(m_search_entry));
+		gtk_widget_set_size_request(m_search_cluster, -1, -1);
 		gtk_widget_set_size_request(GTK_WIDGET(m_search_entry), -1, -1);
 		gtk_widget_set_hexpand(GTK_WIDGET(m_search_entry), TRUE);
 		gtk_widget_set_halign(GTK_WIDGET(m_search_entry), GTK_ALIGN_FILL);
@@ -2805,7 +2847,13 @@ void WhiskerMenu::Window::update_layout()
 	{
 		const int sidebar_w = (m_workarea.width > 0) ? m_workarea.width / 6 : 0;
 		const int col_gap = 6; // m_contents_box column-spacing in vertical-sidebar mode
-		gtk_widget_set_size_request(GTK_WIDGET(m_search_entry),
+		// Fix the *cluster* width (entry + optional trailing switch) to the grid
+		// width so the pair stays centred and the entry shrinks to make room for
+		// the switch rather than the row growing past the Places-off width
+		// (FR-019). The entry itself hexpands inside the cluster, so it owns all
+		// the width when Places is off and yields the switch's share when it is on.
+		gtk_widget_set_size_request(GTK_WIDGET(m_search_entry), -1, -1);
+		gtk_widget_set_size_request(m_search_cluster,
 				m_workarea.width - 2 * sidebar_w - col_gap, -1);
 	}
 

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -206,6 +206,10 @@ private:
 	GtkBox* m_title_box;
 	GtkBox* m_commands_box;
 	GtkBox* m_search_box;
+	// Full-screen unified-bar only: holds the search entry and, when Places is
+	// on, the trailing Apps/Places switch, so the pair is centred as one unit.
+	// Owns a ref because it is unparented in every non-unified layout.
+	GtkWidget* m_search_cluster;
 	GtkStack* m_contents_stack;
 	GtkGrid* m_contents_box;
 	GtkBox* m_categories_box;

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -275,9 +275,6 @@ private:
 	// Forces the two Apps/Places mode buttons to equal width in every layout
 	// and preset, surviving the icon↔text child swap (FR-013).
 	GtkSizeGroup* m_mode_button_size_group;
-	// Ties the Top/Bottom category strip to the search-box width and keeps it
-	// centred (FR-019/020). Built lazily on the first strip layout.
-	GtkSizeGroup* m_strip_width_group;
 
 	GdkRectangle m_geometry;
 	bool m_layout_ltr;
@@ -287,6 +284,9 @@ private:
 	bool m_layout_sidebar_enabled;
 	bool m_layout_switch_show_icons;
 	bool m_layout_category_show_name;
+	// Tracked category icon size so show() re-runs update_layout() when it
+	// changes, keeping the Apps/Places toggle in sync with the category icons.
+	int m_layout_category_icon_size;
 	bool m_layout_categories_alternate;
 	bool m_layout_search_alternate;
 	bool m_layout_commands_alternate;

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -168,14 +168,19 @@ private:
 	 * @long_label: gettext-translated descriptive name ("Applications"/"Places")
 	 *         used for the tooltip + accessible name in both modes, so the full
 	 *         meaning survives even in icon-only mode.
+	 * @icon_px: pixel size for the icon child, derived from the toggle's region
+	 *         (category icon size in a sidebar, search-bar height otherwise);
+	 *         <= 0 leaves the themed default and is used when the toggle is
+	 *         hidden.
 	 *
 	 * Swaps the toggle's child between a GtkLabel and a GtkImage in place,
-	 * leaving the toggle's active state and styling untouched. A no-op when the
-	 * child is already in the requested form.
+	 * leaving the toggle's active state and styling untouched. When the child is
+	 * already an image it is reused and only its icon name and pixel size are
+	 * refreshed, so a live category-icon-size change resizes the toggle too.
 	 */
 	void set_mode_button_content(GtkToggleButton* button, bool show_icons,
 			const char* const* icon_chain, const char* short_label,
-			const char* long_label);
+			const char* long_label, int icon_px);
 
 	/* apply_switch_presentation:
 	 * @pres: the computed presentation for this layout pass.
@@ -249,6 +254,11 @@ private:
 	// (FR-012). Created lazily on the first strip layout; the switch is pinned
 	// outside it (FR-014). nullptr until the sidebar is first shown on top/bottom.
 	GtkScrolledWindow* m_strip_scroll;
+	// Expanding spacer pinned as the leading child of m_category_buttons in
+	// strip mode so the category icons sit flush-trailing while the slack falls
+	// between them and the leading toggle (FR-005). Hidden (and thus ignored in
+	// allocation) in the vertical sidebar. Created lazily with m_strip_scroll.
+	GtkWidget* m_strip_lead_spacer;
 	// Current structural placement of the category list, so update_layout()
 	// only reparents on an actual transition: 1 = vertical sidebar,
 	// 2 = horizontal strip, 3 = hidden (sidebar disabled).

--- a/panel-plugin/places/places-item.cpp
+++ b/panel-plugin/places/places-item.cpp
@@ -133,11 +133,19 @@ PlacesItem::~PlacesItem()
 
 /* open:
  * @screen: GdkScreen used to launch on the correct display.
+ * @parent: a widget in the Places page used to parent the failure dialog; may
+ *          be nullptr (the dialog is then unparented).
  *
  * Opens the file or folder with the system-default handler via GIO. Folders
- * fall back to "exo-open --launch FileManager <path>" on launch failure.
+ * fall back to "exo-open --launch FileManager <path>" on launch failure, with
+ * the path shell-quoted (FR-007) so names containing spaces or shell-significant
+ * characters open the exact target. On failure exactly one error dialog names
+ * the item and states the underlying reason (FR-006).
+ *
+ * NOTE: the caller dispatches this before closing the menu so the item is not
+ * freed mid-open; see PlacesPage::on_row_activated().
  */
-void PlacesItem::open(GdkScreen* screen)
+void PlacesItem::open(GdkScreen* screen, GtkWidget* parent)
 {
 	if (m_uri.empty())
 	{
@@ -157,49 +165,73 @@ void PlacesItem::open(GdkScreen* screen)
 		return;
 	}
 
-	if (error) g_error_free(error);
-	error = nullptr;
-
 	if (m_is_directory)
 	{
 		gchar* path = g_file_get_path(m_file);
 		if (path)
 		{
-			gchar* command = g_strdup_printf("exo-open --launch FileManager \"%s\"", path);
+			// FR-007: quote the path so the helper receives the exact folder
+			// even with spaces, quotes, '$', backticks, or parentheses. The
+			// command is parsed by g_shell_parse_argv inside Element::spawn().
+			gchar* quoted = g_shell_quote(path);
+			gchar* command = g_strdup_printf("exo-open --launch FileManager %s", quoted);
+			// FR-006d: Element::spawn() owns the single failure dialog for this
+			// fallback, so the default-handler error above is dropped here to
+			// avoid stacking a second dialog.
 			spawn(screen, command, nullptr, true, nullptr);
 			g_free(command);
+			g_free(quoted);
 			g_free(path);
+			if (error) g_error_free(error);
 			return;
 		}
+		g_free(path);
 	}
 
-	xfce_dialog_show_error(nullptr, nullptr,
-			_("Unable to open \"%s\"."), m_uri.c_str());
+	// FR-006: exactly one dialog, naming the item with a legible reason.
+	gchar* message = build_open_error_message(error, get_text());
+	GtkWindow* window = parent
+			? GTK_WINDOW(gtk_widget_get_toplevel(parent)) : nullptr;
+	xfce_dialog_show_error(window, nullptr, "%s", message);
+	g_free(message);
+	if (error) g_error_free(error);
 }
 
 //-----------------------------------------------------------------------------
 
-void PlacesItem::open_containing(GdkScreen* screen)
+/* open_containing:
+ * @screen: GdkScreen used to launch on the correct display.
+ * @parent: accepted so the Places open paths share a uniform (screen, parent)
+ *          signature; this path shows no dialog of its own, so it is unused.
+ *
+ * Opens the item's parent folder with the default handler. FR-010: when the
+ * item has no parent (e.g. a filesystem root) this is a defined silent no-op,
+ * and a failed launch is intentionally not reported — never a blank dialog.
+ */
+void PlacesItem::open_containing(GdkScreen* screen, GtkWidget* /*parent*/)
 {
 	if (!m_file)
 	{
 		return;
 	}
-	GFile* parent = g_file_get_parent(m_file);
-	if (!parent)
+	GFile* parent_dir = g_file_get_parent(m_file);
+	if (!parent_dir)
 	{
+		// Defined no-op: no parent to open (FR-010). Never a blank dialog.
 		return;
 	}
-	gchar* uri = g_file_get_uri(parent);
+	gchar* uri = g_file_get_uri(parent_dir);
 	if (uri)
 	{
 		GdkAppLaunchContext* ctx = gdk_display_get_app_launch_context(
 				gdk_screen_get_display(screen ? screen : gdk_screen_get_default()));
+		// NOTE: launch result is intentionally ignored — FR-010 defines this as
+		// a silent no-op on failure rather than an error dialog.
 		g_app_info_launch_default_for_uri(uri, G_APP_LAUNCH_CONTEXT(ctx), nullptr);
 		if (ctx) g_object_unref(ctx);
 		g_free(uri);
 	}
-	g_object_unref(parent);
+	g_object_unref(parent_dir);
 }
 
 //-----------------------------------------------------------------------------
@@ -218,7 +250,15 @@ void PlacesItem::copy_path()
 
 //-----------------------------------------------------------------------------
 
-void PlacesItem::open_in_terminal(GdkScreen* screen)
+/* open_in_terminal:
+ * @screen: GdkScreen used to launch on the correct display.
+ * @parent: accepted so the Places open paths share a uniform (screen, parent)
+ *          signature; Element::spawn() owns any failure dialog, so it is unused.
+ *
+ * Opens a terminal with its working directory set to this folder, via Xfce's
+ * TerminalEmulator launch alias.
+ */
+void PlacesItem::open_in_terminal(GdkScreen* screen, GtkWidget* /*parent*/)
 {
 	if (!m_file || !m_is_directory)
 	{
@@ -231,9 +271,13 @@ void PlacesItem::open_in_terminal(GdkScreen* screen)
 	}
 	// NOTE: defer to Xfce's TerminalEmulator launch alias; this honors the
 	// user's configured terminal without parsing xfce4-session.xml ourselves.
-	gchar* command = g_strdup_printf("exo-open --launch TerminalEmulator --working-directory \"%s\"", path);
+	// FR-008: quote the working directory so the terminal opens in the exact
+	// folder even when its name contains shell-significant characters.
+	gchar* quoted = g_shell_quote(path);
+	gchar* command = g_strdup_printf("exo-open --launch TerminalEmulator --working-directory %s", quoted);
 	spawn(screen, command, path, true, nullptr);
 	g_free(command);
+	g_free(quoted);
 	g_free(path);
 }
 
@@ -256,19 +300,34 @@ void PlacesItem::open_with(GtkWidget* parent)
 			GTK_DIALOG_MODAL,
 			content_type ? content_type : "application/octet-stream");
 
+	GError* error = nullptr;
+	gboolean launch_failed = FALSE;
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_OK)
 	{
 		GAppInfo* app = gtk_app_chooser_get_app_info(GTK_APP_CHOOSER(dialog));
 		if (app)
 		{
 			GList* files = g_list_append(nullptr, m_file);
-			g_app_info_launch(app, files, nullptr, nullptr);
+			launch_failed = !g_app_info_launch(app, files, nullptr, &error);
 			g_list_free(files);
 			g_object_unref(app);
 		}
 	}
+	// Destroy the chooser before reporting, so the error dialog is not parented
+	// to a window that is about to disappear.
 	gtk_widget_destroy(dialog);
 	if (info) g_object_unref(info);
+
+	if (launch_failed)
+	{
+		// FR-009: a failed launch is explained, not silently swallowed.
+		gchar* message = build_open_error_message(error, get_text());
+		xfce_dialog_show_error(
+				parent ? GTK_WINDOW(gtk_widget_get_toplevel(parent)) : nullptr,
+				nullptr, "%s", message);
+		g_free(message);
+	}
+	if (error) g_error_free(error);
 }
 
 //-----------------------------------------------------------------------------
@@ -331,6 +390,47 @@ gchar* PlacesItem::places_filter_casefold(const gchar* filter)
 		return nullptr;
 	}
 	return g_utf8_casefold(filter, -1);
+}
+
+//-----------------------------------------------------------------------------
+
+gchar* PlacesItem::build_open_error_message(const GError* error, const char* display_name)
+{
+	const char* name = (display_name && *display_name)
+			? display_name : _("the selected item");
+
+	// Prefer the underlying, already-localized GIO/spawn reason; fall back to a
+	// defined non-empty phrasing so a failed open is never reported blank.
+	const char* reason = (error && error->message && *error->message)
+			? error->message : _("the location could not be opened");
+
+	gchar* raw = g_strdup_printf(_("Unable to open \"%s\": %s"), name, reason);
+
+	// Walk the message one UTF-8 character at a time, dropping invalid bytes and
+	// control characters, so a corrupt reason can never render as a garbled
+	// dialog. g_utf8_get_char_validated() flags malformed/incomplete sequences;
+	// such bytes are skipped rather than copied.
+	GString* clean = g_string_new(nullptr);
+	const char* p = raw;
+	while (*p)
+	{
+		gunichar c = g_utf8_get_char_validated(p, -1);
+		if (c == static_cast<gunichar>(-1) || c == static_cast<gunichar>(-2))
+		{
+			// Invalid or incomplete sequence: drop one byte and resync.
+			++p;
+			continue;
+		}
+		const char* next = g_utf8_next_char(p);
+		if (c >= 0x20 && c != 0x7f)
+		{
+			g_string_append_len(clean, p, next - p);
+		}
+		p = next;
+	}
+	g_free(raw);
+
+	return g_string_free(clean, FALSE);
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/places/places-item.h
+++ b/panel-plugin/places/places-item.h
@@ -52,10 +52,10 @@ public:
 	void set_accessed(gint64 t) { m_accessed = t; }
 	void set_is_favourite(bool v) { m_is_favourite = v; }
 
-	void open(GdkScreen* screen);
-	void open_containing(GdkScreen* screen);
+	void open(GdkScreen* screen, GtkWidget* parent);
+	void open_containing(GdkScreen* screen, GtkWidget* parent);
 	void copy_path();
-	void open_in_terminal(GdkScreen* screen);
+	void open_in_terminal(GdkScreen* screen, GtkWidget* parent);
 	void open_with(GtkWidget* parent);
 	void add_desktop_link(GtkWidget* parent);
 
@@ -74,6 +74,23 @@ public:
 	 * Returns: g_malloc'd casefolded copy (caller frees), or nullptr for empty.
 	 */
 	static gchar* places_filter_casefold(const gchar* filter);
+
+	/* build_open_error_message:
+	 * @error: the GError captured from a failed open, or nullptr if the
+	 *         failure produced no error object.
+	 * @display_name: the item's human-readable name; nullptr or empty falls
+	 *         back to a generic phrasing.
+	 *
+	 * Builds the single error-dialog message shown when an open fails: it names
+	 * the item and states a human-readable reason taken from @error->message,
+	 * with a defined non-empty fallback when @error is nullptr or carries an
+	 * empty message. The result is forced to valid UTF-8 with control bytes
+	 * stripped, so a failed open is never reported blank or garbled. GTK-free
+	 * so it is directly unit-testable.
+	 *
+	 * Returns: a newly-allocated string the caller must g_free().
+	 */
+	static gchar* build_open_error_message(const GError* error, const char* display_name);
 
 private:
 	GFile* m_file;

--- a/panel-plugin/places/places-page.cpp
+++ b/panel-plugin/places/places-page.cpp
@@ -381,8 +381,13 @@ void PlacesPage::on_row_activated(GtkTreePath* path)
 		return;
 	}
 	GdkScreen* screen = gtk_widget_get_screen(m_view->get_widget());
+	// Lifetime invariant: dispatch the open BEFORE closing the menu. open() is a
+	// synchronous dispatch — once it returns, the launch has been handed off —
+	// whereas m_window->hide() clears the search entry, which re-runs the filter
+	// and can delete this very item via clear_home_search_items(). Opening first
+	// guarantees the item stays valid for the whole open (FR-001..FR-003).
+	item->open(screen, m_widget);
 	m_window->hide();
-	item->open(screen);
 }
 
 //-----------------------------------------------------------------------------
@@ -438,8 +443,10 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 		[this, item](GtkMenuItem*)
 		{
 			GdkScreen* s = gtk_widget_get_screen(m_view->get_widget());
+			// Dispatch before hide — see on_row_activated(): hide() can free the
+			// item mid-open, so the open must complete first (FR-004).
+			item->open(s, m_widget);
 			m_window->hide();
-			item->open(s);
 		});
 	// "Open" stays present but insensitive for a missing target, matching the
 	// inert primary activation; "Open Containing Folder" below remains enabled
@@ -487,8 +494,9 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 		[this, item](GtkMenuItem*)
 		{
 			GdkScreen* s = gtk_widget_get_screen(m_view->get_widget());
+			// Dispatch before hide — same lifetime invariant as on_row_activated().
+			item->open_containing(s, m_widget);
 			m_window->hide();
-			item->open_containing(s);
 		});
 	append(mi);
 
@@ -504,8 +512,9 @@ void PlacesPage::show_context_menu(PlacesItem* item, GdkEvent* event)
 			[this, item](GtkMenuItem*)
 			{
 				GdkScreen* s = gtk_widget_get_screen(m_view->get_widget());
+				// Dispatch before hide — same lifetime invariant as above.
+				item->open_in_terminal(s, m_widget);
 				m_window->hide();
-				item->open_in_terminal(s);
 			});
 		append(mi);
 	}

--- a/panel-plugin/presets/preset-builtins.cpp
+++ b/panel-plugin/presets/preset-builtins.cpp
@@ -79,6 +79,7 @@ const LayoutPreset WhiskerMenu::BUILTIN_PRESETS[PRESET_BUILTIN_COUNT] = {
 			{ "layout-mode",          PresetValue::from_str("docked")       },
 			{ "unified-bar",          PresetValue::from_bool(false)         },
 			{ "launcher-icon-size",   PresetValue::from_int(2)              }, // Small
+			{ "category-icon-size",   PresetValue::from_int(1)              }, // Smaller
 			{ "hover-switch-category",PresetValue::from_bool(false)         },
 			{ "view-mode-default",    PresetValue::from_str("list")         },
 			{ "default-category",     PresetValue::from_str("favorites")    },
@@ -111,6 +112,7 @@ const LayoutPreset WhiskerMenu::BUILTIN_PRESETS[PRESET_BUILTIN_COUNT] = {
 			{ "layout-mode",          PresetValue::from_str("docked")      },
 			{ "unified-bar",          PresetValue::from_bool(false)        },
 			{ "launcher-icon-size",   PresetValue::from_int(3)             }, // Normal
+			{ "category-icon-size",   PresetValue::from_int(1)             }, // Smaller
 			{ "grid-density",         PresetValue::from_str("medium")      },
 			{ "hover-switch-category",PresetValue::from_bool(true)         },
 			{ "view-mode-default",    PresetValue::from_str("icons")       },
@@ -145,6 +147,7 @@ const LayoutPreset WhiskerMenu::BUILTIN_PRESETS[PRESET_BUILTIN_COUNT] = {
 			{ "profile-position",     PresetValue::from_str("top")          },
 			{ "commands-position",    PresetValue::from_str("top-right")    },
 			{ "launcher-icon-size",   PresetValue::from_int(4)              }, // Large
+			{ "category-icon-size",   PresetValue::from_int(1)              }, // Smaller
 			{ "grid-density",         PresetValue::from_str("medium")       },
 			{ "layout-mode",          PresetValue::from_str("fullscreen")   },
 			{ "unified-bar",          PresetValue::from_bool(true)          },
@@ -190,6 +193,7 @@ const std::vector<std::string>& WhiskerMenu::governed_keys()
 		"layout-mode",
 		"unified-bar",
 		"launcher-icon-size",
+		"category-icon-size",
 		"hover-switch-category",
 		"view-mode-default",
 		"default-category",

--- a/panel-plugin/presets/preset-io.cpp
+++ b/panel-plugin/presets/preset-io.cpp
@@ -69,6 +69,7 @@ static const PropDef GOVERNED_PROPS[] = {
 	{ "grid-density",          PresetValue::Str, 0, 0, STR_DOMAIN(GRID_DENSITY_DOMAIN) },
 	{ "layout-mode",           PresetValue::Str, 0, 0, STR_DOMAIN(LAYOUT_MODE_DOMAIN) },
 	{ "launcher-icon-size",    PresetValue::Int, INT_RANGE(-1, 6) },
+	{ "category-icon-size",    PresetValue::Int, INT_RANGE(-1, 6) },
 	{ "view-mode-default",     PresetValue::Str, 0, 0, STR_DOMAIN(VIEW_MODE_DOMAIN) },
 	{ "hover-switch-category", PresetValue::Bool, 0, 0, nullptr, 0 },
 	{ "unified-bar",           PresetValue::Bool, 0, 0, nullptr, 0 },

--- a/panel-plugin/presets/preset.cpp
+++ b/panel-plugin/presets/preset.cpp
@@ -83,6 +83,8 @@ void WhiskerMenu::apply_preset(const LayoutPreset& preset, Settings& settings)
 			settings.layout_mode = val.s;
 		else if (prop == "launcher-icon-size" && val.kind == PresetValue::Int)
 			settings.launcher_icon_size = val.i;
+		else if (prop == "category-icon-size" && val.kind == PresetValue::Int)
+			settings.category_icon_size = val.i;
 		else if (prop == "hover-switch-category" && val.kind == PresetValue::Bool)
 			settings.category_hover_activate = val.b;
 		else if (prop == "view-mode-default" && val.kind == PresetValue::Str)
@@ -278,6 +280,11 @@ bool WhiskerMenu::compute_preset_diff(const LayoutPreset& preset, const Settings
 		else if (prop == "launcher-icon-size")
 		{
 			if (val.kind == PresetValue::Int && static_cast<int>(settings.launcher_icon_size) != val.i)
+				return true;
+		}
+		else if (prop == "category-icon-size")
+		{
+			if (val.kind == PresetValue::Int && static_cast<int>(settings.category_icon_size) != val.i)
 				return true;
 		}
 		else if (prop == "hover-switch-category")
@@ -516,6 +523,7 @@ std::string WhiskerMenu::save_current_as_user_preset(const std::string& display_
 	xfconf_channel_set_bool(ch, (prefix + "unified-bar").c_str(),
 		static_cast<bool>(settings.unified_bar));
 	xfconf_channel_set_int(ch, (prefix + "launcher-icon-size").c_str(), settings.launcher_icon_size);
+	xfconf_channel_set_int(ch, (prefix + "category-icon-size").c_str(), settings.category_icon_size);
 	xfconf_channel_set_bool(ch, (prefix + "hover-switch-category").c_str(),
 		static_cast<bool>(settings.category_hover_activate));
 	const gchar* vm_str = "list";

--- a/panel-plugin/settings-defaults.cpp
+++ b/panel-plugin/settings-defaults.cpp
@@ -28,24 +28,47 @@ using namespace WhiskerMenu;
 //-----------------------------------------------------------------------------
 
 /* migrate_schema:
- * @is_fresh_install: true when no Xfconf properties were present at load.
+ * @marker:        value of the persisted /initialized key at load time.
+ * @empty_channel: true when no plugin Xfconf properties were present at load.
  *
- * Walks the channel forward through every known schema version, applying
- * additive migrations. Versions are cumulative: each block runs once per
- * upgrade. The defaults tables here are the single source of truth for
- * Xfconf key defaults seeded on schema upgrade; they MUST stay aligned
- * with the inline defaults supplied in the Settings constructor.
+ * Decides fresh-vs-upgrade from the marker (authoritative), not the raw
+ * property count, then walks the channel forward through every known schema
+ * version applying additive migrations. Versions are cumulative: each block
+ * runs once per upgrade. The defaults tables here are the single source of
+ * truth for Xfconf key defaults seeded on schema upgrade; they MUST stay
+ * aligned with the inline defaults supplied in the Settings constructor.
+ *
+ * Decision (contracts/fresh-vs-upgrade-decision.md):
+ *   - marker absent AND empty channel  ⇒ FRESH: apply the Modern preset.
+ *   - marker present                   ⇒ UPGRADE: preserve the user's layout.
+ *   - marker absent with stored config ⇒ UPGRADE (existing user's first
+ *                                        marker-aware run): preserve layout,
+ *                                        derive identity, back-fill the marker.
+ *   - present but unmigratable config  ⇒ degrades to a safe Modern-equivalent
+ *                                        state (xfconf getters fall back to
+ *                                        defaults); never crashes, never
+ *                                        forces Classic.
+ *
+ * INVARIANT: a `true` marker NEVER causes a layout reset. The marker is
+ * back-filled on every path so a still-running xfconfd serving stale state can
+ * never trigger a later reset.
  */
-void Settings::migrate_schema(bool is_fresh_install)
+void Settings::migrate_schema(bool marker, bool empty_channel)
 {
 	if (!channel)
 		return;
 
-	const int current_schema = 5;
-	if (schema_version >= current_schema)
-		return;
+	// Marker is authoritative: only a never-initialized, genuinely empty
+	// channel is a fresh install. Everything else is an upgrade.
+	const bool is_fresh_install = !marker && empty_channel;
 
 	begin_property_update();
+
+	// Fresh installs land on Modern (applied once, up front, so it runs
+	// regardless of the stored schema version). Upgrades intentionally skip
+	// this and keep the user's stored layout untouched.
+	if (is_fresh_install)
+		apply_preset(BUILTIN_PRESETS[PRESET_MODERN], *this);
 
 	if (schema_version < 1)
 	{
@@ -99,13 +122,12 @@ void Settings::migrate_schema(bool is_fresh_install)
 				xfconf_channel_set_string(channel, p.prop, p.val);
 		}
 
-		// Fresh installs land on Modern. Upgrades intentionally leave
-		// current_preset_id unset here — the v5 step derives the active-preset
-		// identity from the user's actual layout instead of hard-defaulting to
-		// "classic" (which would mislabel a non-classic layout). The user's
-		// stored layout values are never touched on upgrade.
-		if (is_fresh_install)
-			apply_preset(BUILTIN_PRESETS[PRESET_MODERN], *this);
+		// NOTE: the fresh-install Modern preset is applied up front (see the
+		// top of this function), not here. Upgrades intentionally leave
+		// current_preset_id unset in this block — the v5 step derives the
+		// active-preset identity from the user's actual layout instead of
+		// hard-defaulting to "classic" (which would mislabel a non-classic
+		// layout). The user's stored layout values are never touched on upgrade.
 
 		schema_version = 1;
 	}
@@ -275,6 +297,12 @@ void Settings::migrate_schema(bool is_fresh_install)
 
 		schema_version = 5;
 	}
+
+	// Back-fill the marker on every path (fresh, upgrade, or already-current
+	// schema) so the next load is unambiguously an upgrade and the user's
+	// layout is never reset again. Written inside the active begin/end batch.
+	if (!marker)
+		initialized = true;
 
 	end_property_update();
 }

--- a/panel-plugin/settings-dialog.cpp
+++ b/panel-plugin/settings-dialog.cpp
@@ -600,6 +600,9 @@ void SettingsDialog::sync_preset_widgets()
 	if (m_item_icon_size)
 		gtk_combo_box_set_active(GTK_COMBO_BOX(m_item_icon_size),
 			static_cast<int>(m_settings->launcher_icon_size) + 1);
+	if (m_category_icon_size)
+		gtk_combo_box_set_active(GTK_COMBO_BOX(m_category_icon_size),
+			static_cast<int>(m_settings->category_icon_size) + 1);
 	if (m_position_categories_horizontal)
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_position_categories_horizontal),
 			static_cast<bool>(m_settings->position_categories_horizontal));

--- a/panel-plugin/settings-dialog.cpp
+++ b/panel-plugin/settings-dialog.cpp
@@ -697,13 +697,30 @@ void SettingsDialog::refresh_preset_combo(const std::string& select_id)
 			p.id.c_str(), label.c_str());
 	}
 
-	// Restore selection
+	// Restore selection. The preset field must never be blank (FR-005): when the
+	// stored id is unset or resolves to no row (empty, or a deleted/unknown
+	// preset), present and select a synthetic non-blank "Custom" entry that
+	// truthfully represents the current preset-less layout state.
+	// HACK: gtk_combo_box_set_active_id silently leaves the combo with no active
+	// selection when the id matches no row, which is exactly the blank case we
+	// must avoid; we detect that via its return value and fall back to "Custom".
+	static const char* const CUSTOM_PLACEHOLDER_ID = "__custom__";
+	bool selected = false;
 	if (!active_id.empty())
+		selected = gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_preset_combo), active_id.c_str());
+
+	bool is_custom_placeholder = false;
+	if (!selected)
 	{
-		gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_preset_combo), active_id.c_str());
+		gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(m_preset_combo),
+			CUSTOM_PLACEHOLDER_ID, _("Custom"));
+		gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_preset_combo), CUSTOM_PLACEHOLDER_ID);
+		is_custom_placeholder = true;
 	}
 
-	// Update button sensitivity: Rename/Delete only for user (non-builtin) presets.
+	// Update button sensitivity: Rename/Delete only for user (non-builtin)
+	// presets. The synthetic "Custom" placeholder is not a real preset, so it
+	// must never enable the user-preset actions.
 	bool is_builtin = false;
 	for (const auto& p : get_file_presets())
 		if (p.id == active_id) { is_builtin = true; break; }
@@ -712,7 +729,8 @@ void SettingsDialog::refresh_preset_combo(const std::string& select_id)
 		for (int i = 0; i < PRESET_BUILTIN_COUNT; ++i)
 			if (BUILTIN_PRESETS[i].id == active_id) { is_builtin = true; break; }
 	}
-	bool is_user = (gtk_combo_box_get_active_id(GTK_COMBO_BOX(m_preset_combo)) != nullptr)
+	bool is_user = !is_custom_placeholder
+		&& (gtk_combo_box_get_active_id(GTK_COMBO_BOX(m_preset_combo)) != nullptr)
 		&& !is_builtin;
 	if (m_preset_rename_btn)
 		gtk_widget_set_sensitive(m_preset_rename_btn, is_user);

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -114,6 +114,7 @@ Settings::Settings(Plugin* plugin) :
 
 	schema_version(this, "/schema-version", 0, 0, G_MAXINT),
 	current_preset_id(this, "/current-preset-id"),
+	initialized(this, "/initialized", false),
 
 	corner_radius(this, "/corner-radius", 0, 0, 24),
 	panel_gap(this, "/panel-gap", 0, 0, 50),
@@ -379,7 +380,13 @@ void Settings::load(const gchar* base)
 	g_hash_table_destroy(properties);
 	prevent_invalid();
 	load_aliases(channel);
-	migrate_schema(loaded_property_count == 0);
+	// NOTE: the persisted /initialized marker — not the raw property count — is
+	// the authoritative fresh-vs-upgrade signal. The count is fragile: a
+	// still-running xfconfd that served stale in-memory state (or panel-seeded
+	// keys) makes a genuine first run look non-empty. Passing both lets
+	// migrate_schema treat "marker absent AND empty channel" as the only fresh
+	// case while still back-filling the marker for existing users.
+	migrate_schema(initialized, loaded_property_count == 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -388,19 +395,24 @@ void Settings::load(const gchar* base)
  *
  * Resolves the active preset's stored identity name for display as the
  * active-preset label. A single code path serves built-ins (localized display
- * name) and custom presets (user-entered stored name). Falls back to the raw
- * stored id if the id resolves to no known preset (e.g. a deleted custom one).
+ * name) and custom presets (user-entered stored name). When the id is
+ * unset/empty or resolves to no known preset (e.g. a deleted custom one), the
+ * localized "Custom" label is returned so the field is never blank.
  *
- * Returns: the name to show; never the hard-coded "Classic" default.
+ * Returns: the name to show; never empty, never the hard-coded "Classic"
+ * default. The "Custom" wording matches save_current_as_user_preset.
  */
 std::string Settings::current_preset_name() const
 {
 	const gchar* id = static_cast<const gchar*>(current_preset_id);
 	const std::string sid = id ? id : "";
-	const LayoutPreset* p = find_preset_by_id(sid);
-	if (p)
-		return p->name.empty() ? p->display_name : p->name;
-	return sid;
+	if (!sid.empty())
+	{
+		const LayoutPreset* p = find_preset_by_id(sid);
+		if (p)
+			return p->name.empty() ? p->display_name : p->name;
+	}
+	return _("Custom");
 }
 
 void Settings::prevent_invalid()
@@ -487,6 +499,7 @@ void Settings::property_changed(const gchar* property, const GValue* value)
 			|| frecency_alpha.load(property, value)
 			|| schema_version.load(property, value)
 			|| current_preset_id.load(property, value)
+			|| initialized.load(property, value)
 			|| corner_radius.load(property, value)
 			|| panel_gap.load(property, value)
 			|| categories_opacity.load(property, value)

--- a/panel-plugin/settings.h
+++ b/panel-plugin/settings.h
@@ -406,6 +406,13 @@ public:
 	Integer schema_version;
 	String  current_preset_id;
 
+	// Persisted first-run marker. Records that the launcher has completed
+	// initialization. This — not the raw Xfconf property count — is the
+	// authoritative fresh-vs-upgrade signal: it stays correct even when a
+	// still-running xfconfd serves stale in-memory state for the channel.
+	// Internal flag only; not exposed in the GUI.
+	Boolean initialized;
+
 	// Active preset's stored identity name, surfaced as the active-preset label.
 	// Built-ins return their localized display name, custom presets their stored
 	// name; falls back to the stored id when no preset matches.
@@ -452,7 +459,7 @@ public:
 	// icon-only mode never overwrite it.
 	Boolean places_switch_show_icons;
 
-	void migrate_schema(bool is_fresh_install);
+	void migrate_schema(bool marker, bool empty_channel);
 
 	friend class Plugin;
 

--- a/panel-plugin/ui/properties/general.cpp
+++ b/panel-plugin/ui/properties/general.cpp
@@ -443,10 +443,14 @@ GtkWidget* SettingsDialog::init_general_tab()
 			}
 		});
 
-	// Populate preset combo and initial description.
-	refresh_preset_combo(static_cast<const gchar*>(m_settings->current_preset_id)
-		? std::string(static_cast<const gchar*>(m_settings->current_preset_id))
-		: std::string());
+	// Populate preset combo and initial description. Pass the stored active
+	// identity so the field reflects it on open; when the id is unset or
+	// resolves to no preset, refresh_preset_combo selects a non-blank "Custom"
+	// entry rather than leaving the field empty (FR-005/006).
+	{
+		const gchar* pid = static_cast<const gchar*>(m_settings->current_preset_id);
+		refresh_preset_combo(pid ? std::string(pid) : std::string());
+	}
 	{
 		const gchar* pid = gtk_combo_box_get_active_id(GTK_COMBO_BOX(m_preset_combo));
 		const LayoutPreset* preset = find_preset_by_id(pid ? std::string(pid) : std::string());

--- a/panel-plugin/ui/properties/sidebar.cpp
+++ b/panel-plugin/ui/properties/sidebar.cpp
@@ -133,7 +133,11 @@ GtkWidget* SettingsDialog::init_sidebar_tab()
 	connect(m_category_icon_size, "changed",
 		[this](GtkComboBox* combo)
 		{
+			if (m_programmatic_update)
+				return;
 			m_settings->category_icon_size = gtk_combo_box_get_active(combo) - 1;
+			m_plugin->reload_menu();
+			refresh_customized_indicator();
 		});
 
 	// Sidebar opacity (renamed from "Category opacity"; enable-when-docked).

--- a/po/xfce4-meowmenu-plugin.pot
+++ b/po/xfce4-meowmenu-plugin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xfce4-meowmenu-plugin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-04 17:15+0200\n"
+"POT-Creation-Date: 2026-06-04 23:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -194,31 +194,39 @@ msgstr ""
 msgid "%s (missing)"
 msgstr ""
 
-#: panel-plugin/places/places-item.cpp:177
-#, c-format
-msgid "Unable to open \"%s\"."
+#: panel-plugin/places/places-item.cpp:360
+msgid "Unable to add desktop link."
 msgstr ""
 
-#: panel-plugin/places/places-item.cpp:301
-msgid "Unable to add desktop link."
+#: panel-plugin/places/places-item.cpp:400
+msgid "the selected item"
+msgstr ""
+
+#: panel-plugin/places/places-item.cpp:405
+msgid "the location could not be opened"
+msgstr ""
+
+#: panel-plugin/places/places-item.cpp:407
+#, c-format
+msgid "Unable to open \"%s\": %s"
 msgstr ""
 
 #: panel-plugin/places/places-page.cpp:64
 msgid "No items to show."
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:436
+#: panel-plugin/places/places-page.cpp:441
 msgid "_Open"
 msgstr ""
 
 #. Left enabled for missing favourites (not gated on exists()) so a
 #. stale favourite can always be removed even though "Open" above is
 #. greyed — this is the greyed-out-favourite behaviour from 005.
-#: panel-plugin/places/places-page.cpp:459
+#: panel-plugin/places/places-page.cpp:466
 msgid "Remove from Favourites"
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:470
+#: panel-plugin/places/places-page.cpp:477
 msgid "Add to Favourites"
 msgstr ""
 
@@ -226,23 +234,23 @@ msgstr ""
 #. enabled even when the target is missing so a renamed file can be located
 #. from its parent folder. PlacesItem::open_containing() fails silently (no
 #. dialog) when the parent is also gone.
-#: panel-plugin/places/places-page.cpp:485
+#: panel-plugin/places/places-page.cpp:492
 msgid "Open Containing Folder"
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:495
+#: panel-plugin/places/places-page.cpp:503
 msgid "Copy Path"
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:502
+#: panel-plugin/places/places-page.cpp:510
 msgid "Open in Terminal"
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:514
+#: panel-plugin/places/places-page.cpp:523
 msgid "Open With…"
 msgstr ""
 
-#: panel-plugin/places/places-page.cpp:519
+#: panel-plugin/places/places-page.cpp:528
 msgid "Add Desktop Link"
 msgstr ""
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -107,6 +107,27 @@ test_home_search = executable(
 
 test('home_search', test_home_search)
 
+# test_places_open: GTK-free coverage of the Places open-path hardening —
+# the g_shell_quote round-trip handed to the external helper (FR-007/008) and
+# the open-failure reason string built for the error dialog (FR-006). Compiles
+# places-item.cpp plus its Element base (element.cpp) directly into the binary,
+# mirroring test_home_search_lifecycle; no display is needed for these pure
+# helpers, so the binary runs headless.
+test_places_open_sources = [
+  'test_places_open.cpp',
+  '..' / 'panel-plugin' / 'places' / 'places-item.cpp',
+  '..' / 'panel-plugin' / 'launcher' / 'element.cpp',
+]
+
+test_places_open = executable(
+  'test_places_open',
+  test_places_open_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [glib, gio, gtk, libxfce4ui, libxfce4util],
+)
+
+test('places_open', test_places_open)
+
 # NOTE: test_migration covers the T1..T7 contract from
 # .specify/specs/010-standalone-identity/contracts/xfconf-migration.md.
 # It exercises panel-plugin/migration.cpp directly (source compiled into

--- a/tests/test_places_open.cpp
+++ b/tests/test_places_open.cpp
@@ -1,0 +1,139 @@
+/*
+ * Unit tests for the Places open-path hardening logic.
+ *
+ * Covers the two pieces of the open path that are exercisable without a
+ * display: the shell-quote round-trip used to hand paths to the external
+ * helper, and the open-failure reason string built for the error dialog.
+ *
+ * NOTE: the item-lifetime fix and the single-dialog discipline are UI-flow
+ * properties that cannot be driven by this headless harness; they are covered
+ * by the manual verification steps in the feature's quickstart.
+ *
+ * Like the other tests in this folder, the production translation unit
+ * (places-item.cpp) is compiled directly into the binary rather than linked
+ * against the plugin library; element.cpp supplies the Element base symbols it
+ * pulls in.
+ */
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "places/places-item.h"
+
+using WhiskerMenu::PlacesItem;
+
+// Reject the C0 control range (and DEL) — an open-failure message must be
+// legible, so any control byte counts as garbage for this check. Tab/newline
+// are not expected in a one-line dialog message either.
+static bool has_control_bytes(const char* s)
+{
+	for (const guchar* p = reinterpret_cast<const guchar*>(s); *p; ++p)
+	{
+		if (*p < 0x20 || *p == 0x7f)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// FR-006: the reason string maps a GError + display name to a non-empty,
+// named, legible message.
+// ---------------------------------------------------------------------------
+
+static void test_error_message_contains_name_and_reason()
+{
+	GError* error = g_error_new_literal(G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+			"No application is registered as handling this file");
+	gchar* msg = PlacesItem::build_open_error_message(error, "report.odt");
+
+	assert(msg && *msg);                                  // non-empty (FR-006c)
+	assert(strstr(msg, "report.odt") != nullptr);         // names the item (FR-006a)
+	assert(strstr(msg, "No application is registered") != nullptr); // reason (FR-006b)
+	assert(g_utf8_validate(msg, -1, nullptr));
+	assert(!has_control_bytes(msg));                      // legible (FR-006c)
+
+	g_free(msg);
+	g_error_free(error);
+}
+
+static void test_error_message_nonempty_without_gerror()
+{
+	// No GError object at all must still yield a non-empty, named reason.
+	gchar* msg = PlacesItem::build_open_error_message(nullptr, "weird name.bin");
+	assert(msg && *msg);
+	assert(strstr(msg, "weird name.bin") != nullptr);
+	assert(!has_control_bytes(msg));
+	g_free(msg);
+}
+
+static void test_error_message_strips_control_bytes()
+{
+	// A reason carrying stray control bytes must be sanitised, never surfaced
+	// raw into the dialog.
+	GError* error = g_error_new_literal(G_IO_ERROR, G_IO_ERROR_FAILED,
+			"bad\x01\x02reason\x7f");
+	gchar* msg = PlacesItem::build_open_error_message(error, "f.txt");
+	assert(msg && *msg);
+	assert(!has_control_bytes(msg));
+	assert(g_utf8_validate(msg, -1, nullptr));
+	g_free(msg);
+	g_error_free(error);
+}
+
+// ---------------------------------------------------------------------------
+// FR-007/FR-008: a path quoted with g_shell_quote round-trips through
+// g_shell_parse_argv (the parse Element::spawn performs) to the exact literal
+// path, so the external helper receives the right target and no embedded
+// command can run.
+// ---------------------------------------------------------------------------
+
+static void assert_quote_round_trip(const char* path)
+{
+	gchar* quoted = g_shell_quote(path);
+	// Mirror Element::spawn(): the helper command is "exo-open … <quoted>".
+	gchar* command = g_strdup_printf("exo-open --launch FileManager %s", quoted);
+
+	gchar** argv = nullptr;
+	GError* error = nullptr;
+	const gboolean ok = g_shell_parse_argv(command, nullptr, &argv, &error);
+	assert(ok && argv);
+
+	// argv = { "exo-open", "--launch", "FileManager", <path> } — the last token
+	// must equal the original path byte-for-byte.
+	guint n = g_strv_length(argv);
+	assert(n == 4);
+	assert(g_strcmp0(argv[n - 1], path) == 0);
+
+	g_strfreev(argv);
+	g_free(command);
+	g_free(quoted);
+}
+
+static void test_shell_quote_round_trip()
+{
+	assert_quote_round_trip("/home/u/plain.txt");
+	assert_quote_round_trip("/home/u/with space.txt");
+	assert_quote_round_trip("/home/u/a \"b\" $(c).txt");
+	assert_quote_round_trip("/home/u/weird $(dir) \"name\"");
+	assert_quote_round_trip("/home/u/`backtick`.txt");
+	assert_quote_round_trip("/home/u/dollar$VAR and (parens).txt");
+	assert_quote_round_trip("/home/u/trailing backslash\\");
+	assert_quote_round_trip("/home/u/single'quote.txt");
+}
+
+// ---------------------------------------------------------------------------
+
+int main()
+{
+	test_error_message_contains_name_and_reason();
+	test_error_message_nonempty_without_gerror();
+	test_error_message_strips_control_bytes();
+	test_shell_quote_round_trip();
+	return 0;
+}

--- a/tests/test_preset.cpp
+++ b/tests/test_preset.cpp
@@ -397,6 +397,46 @@ static void test_find_by_id()
 }
 
 // ---------------------------------------------------------------------------
+// Preset-field label resolution (contracts/preset-field-label.md).
+// Pure mirror of Settings::current_preset_name(): a known id yields the
+// preset's stored name; an unset/empty id or one that resolves to no known
+// preset yields the localized "Custom" string. The result is never empty.
+// ---------------------------------------------------------------------------
+
+/* resolve_preset_label:
+ * @id:          stored active-preset identity (may be empty).
+ * @lookup_name: the resolved preset's name, or nullptr if the id resolves to
+ *               no known preset.
+ *
+ * Returns: the label to display; never empty.
+ */
+static std::string resolve_preset_label(const std::string& id, const char* lookup_name)
+{
+	if (!id.empty() && lookup_name && *lookup_name)
+		return lookup_name;
+	return "Custom";
+}
+
+static void test_preset_label_resolution()
+{
+	// Known built-in / user ids adopt their resolved name.
+	assert(resolve_preset_label("modern", "Modern") == "Modern");
+	assert(resolve_preset_label("classic", "Classic") == "Classic");
+	assert(resolve_preset_label("uuid-7", "My Layout") == "My Layout");
+
+	// Unset/empty id → "Custom"; lookup is irrelevant.
+	assert(resolve_preset_label("", nullptr) == "Custom");
+	assert(resolve_preset_label("", "Modern") == "Custom");
+
+	// Non-empty but unknown id (resolves to nothing) → "Custom".
+	assert(resolve_preset_label("deleted-uuid", nullptr) == "Custom");
+
+	// The label is never empty in any state.
+	assert(!resolve_preset_label("", nullptr).empty());
+	assert(!resolve_preset_label("ghost", nullptr).empty());
+}
+
+// ---------------------------------------------------------------------------
 // Shadow user-preset store — mirrors the CRUD logic in preset.cpp without Xfconf.
 // ---------------------------------------------------------------------------
 
@@ -810,6 +850,7 @@ int main()
 	test_fullscreen_sidebar_left();
 	test_fullscreen_to_docked_restores_menu_size();
 	test_find_by_id();
+	test_preset_label_resolution();
 	// T084: user preset CRUD
 	test_user_preset_save_then_enumerate();
 	test_user_preset_rename_updates_name();

--- a/tests/test_schema_migration.cpp
+++ b/tests/test_schema_migration.cpp
@@ -163,6 +163,138 @@ static bool detect_fresh_install(unsigned int property_count)
 	return property_count == 0;
 }
 
+// ---------------------------------------------------------------------------
+// Marker-aware fresh-vs-upgrade decision (contracts/fresh-vs-upgrade-decision.md)
+// ---------------------------------------------------------------------------
+
+enum FreshUpgradeResult { FU_FRESH, FU_UPGRADE, FU_SAFE_FALLBACK };
+
+enum ConfigState { CFG_NONE, CFG_READABLE, CFG_CORRUPT };
+
+/* decide_fresh_vs_upgrade:
+ * @marker:         value of the persisted /initialized key (absent ⇒ false).
+ * @property_count: number of plugin properties present at load.
+ * @config_state:   whether stored config is none/readable/corrupt.
+ * @out_apply_modern: set to whether the Modern preset must be applied.
+ * @out_set_marker:   set to whether /initialized must be written true.
+ *
+ * Pure mirror of the gate implemented in Settings::migrate_schema. The marker
+ * — not the raw property count — is the authoritative fresh-vs-upgrade signal:
+ * a present marker always means UPGRADE (never reset the user's layout). The
+ * property count only distinguishes a truly empty channel from an existing
+ * user's first marker-aware run when the marker is absent.
+ *
+ * Returns: the classification for the given inputs.
+ */
+static FreshUpgradeResult decide_fresh_vs_upgrade(bool marker,
+	unsigned int property_count, ConfigState config_state,
+	bool* out_apply_modern, bool* out_set_marker)
+{
+	// Every completed path back-fills the marker so the next load is an upgrade.
+	*out_set_marker = true;
+
+	if (marker)
+	{
+		// Marker present ⇒ upgrade regardless of count/config; never reset.
+		*out_apply_modern = false;
+		return FU_UPGRADE;
+	}
+
+	if (property_count == 0 && config_state == CFG_NONE)
+	{
+		*out_apply_modern = true;
+		return FU_FRESH;
+	}
+
+	if (config_state == CFG_CORRUPT)
+	{
+		// Present but unmigratable ⇒ safe Modern fallback; never force Classic.
+		*out_apply_modern = true;
+		return FU_SAFE_FALLBACK;
+	}
+
+	// Marker absent but readable config ⇒ existing user's first marker-aware
+	// run: preserve layout, derive identity, back-fill the marker.
+	*out_apply_modern = false;
+	return FU_UPGRADE;
+}
+
+static void test_marker_decision_table()
+{
+	bool apply_modern = false, set_marker = false;
+
+	// Row 1: marker absent + empty channel ⇒ FRESH (Modern + marker set).
+	assert(decide_fresh_vs_upgrade(false, 0, CFG_NONE, &apply_modern, &set_marker) == FU_FRESH);
+	assert(apply_modern == true && set_marker == true);
+
+	// Row 2: marker absent + readable config ⇒ UPGRADE (preserve, back-fill).
+	assert(decide_fresh_vs_upgrade(false, 7, CFG_READABLE, &apply_modern, &set_marker) == FU_UPGRADE);
+	assert(apply_modern == false && set_marker == true);
+
+	// Row 3: marker present ⇒ UPGRADE (no reset), any count/config.
+	assert(decide_fresh_vs_upgrade(true, 0, CFG_NONE, &apply_modern, &set_marker) == FU_UPGRADE);
+	assert(apply_modern == false && set_marker == true);
+	assert(decide_fresh_vs_upgrade(true, 42, CFG_READABLE, &apply_modern, &set_marker) == FU_UPGRADE);
+	assert(apply_modern == false && set_marker == true);
+	assert(decide_fresh_vs_upgrade(true, 3, CFG_CORRUPT, &apply_modern, &set_marker) == FU_UPGRADE);
+	assert(apply_modern == false && set_marker == true);
+
+	// Row 4: marker absent + corrupt/unmigratable config ⇒ SAFE FALLBACK.
+	assert(decide_fresh_vs_upgrade(false, 5, CFG_CORRUPT, &apply_modern, &set_marker) == FU_SAFE_FALLBACK);
+	assert(apply_modern == true && set_marker == true);
+
+	// Postcondition (all paths): the marker is always set true afterwards.
+}
+
+/* apply_decision_to_identity:
+ * Models the observable identity/layout outcome of migrate_schema for the given
+ * decision inputs. On a path that applies Modern, the active-preset identity
+ * becomes "modern" and the layout is the Modern layout; otherwise the existing
+ * identity and layout are preserved verbatim (no reset on upgrade).
+ */
+static void apply_decision_to_identity(bool marker, unsigned int property_count,
+	ConfigState config_state, const char** identity, const char** layout)
+{
+	bool apply_modern = false, set_marker = false;
+	decide_fresh_vs_upgrade(marker, property_count, config_state,
+		&apply_modern, &set_marker);
+	if (apply_modern)
+	{
+		*identity = "modern";
+		*layout = "modern-layout";
+	}
+	// else: leave identity/layout untouched — upgrades preserve the user's data.
+}
+
+static void test_fresh_install_records_modern_identity()
+{
+	// Acceptance scenario 1: a genuinely fresh install lands on Modern and
+	// records the Modern active-preset identity.
+	const char* identity = "";
+	const char* layout = "";
+	apply_decision_to_identity(false, 0, CFG_NONE, &identity, &layout);
+	assert(std::strcmp(identity, "modern") == 0);
+	assert(std::strcmp(layout, "modern-layout") == 0);
+}
+
+static void test_upgrade_preserves_customized_layout()
+{
+	// Acceptance scenario 3: an upgrade with a customized layout is preserved,
+	// never reset to Modern, whether the marker is present or being back-filled.
+	const char* identity = "my-custom";
+	const char* layout = "custom-layout";
+	apply_decision_to_identity(true, 12, CFG_READABLE, &identity, &layout);
+	assert(std::strcmp(identity, "my-custom") == 0);
+	assert(std::strcmp(layout, "custom-layout") == 0);
+
+	// Marker-absent-but-readable (first marker-aware run) also preserves layout.
+	identity = "classic";
+	layout = "classic-layout";
+	apply_decision_to_identity(false, 12, CFG_READABLE, &identity, &layout);
+	assert(std::strcmp(identity, "classic") == 0);
+	assert(std::strcmp(layout, "classic-layout") == 0);
+}
+
 static int map_legacy_opacity(int has_categories_opacity, int legacy_menu_opacity)
 {
 	// If categories-opacity is already set, keep it; otherwise use legacy.
@@ -339,6 +471,9 @@ int main()
 {
 	test_schema_version_guard();
 	test_fresh_install_detection();
+	test_marker_decision_table();
+	test_fresh_install_records_modern_identity();
+	test_upgrade_preserves_customized_layout();
 	test_legacy_opacity_mapping();
 	test_full_screen_opacity_default();
 	test_position_categories_horizontal_migration();

--- a/tests/test_sidebar_layout.cpp
+++ b/tests/test_sidebar_layout.cpp
@@ -166,23 +166,44 @@ void parse_positions()
 	CHECK(meow_parse_sidebar_position("nonsense") == SidebarPosition::Left);
 }
 
-// T023: Top/Bottom strip stacking order and width source (FR-017/018/020).
+// Top/Bottom strip stacking order, row anchoring, and width source
+// (FR-005/006/017/018/020). The toggle anchors leading and the category group
+// trailing on a single row; the order is direction-independent and the anchors
+// are direction-relative, so both LTR and RTL resolve identically here.
 void strip_geometry_ordering()
 {
-	// Bottom → strip below the results box; Top → strip above. The order is
-	// direction-independent: identical in LTR and RTL.
+	// Bottom → strip below the results box; Top → strip above. Anchoring is
+	// identical in LTR and RTL: toggle Leading, categories Trailing, always.
 	for (bool ltr : { true, false })
 	{
 		StripGeometry top = meow_compute_strip_geometry(SidebarPosition::Top, ltr);
 		CHECK(top.order == StripOrder::StripAboveResults);
-		CHECK(top.centred);
+		CHECK(top.toggle_anchor == StripAnchor::Leading);
+		CHECK(top.categories_anchor == StripAnchor::Trailing);
 		CHECK(top.width_from_search_box);
 
 		StripGeometry bottom = meow_compute_strip_geometry(SidebarPosition::Bottom, ltr);
 		CHECK(bottom.order == StripOrder::StripBelowResults);
-		CHECK(bottom.centred);
+		CHECK(bottom.toggle_anchor == StripAnchor::Leading);
+		CHECK(bottom.categories_anchor == StripAnchor::Trailing);
 		CHECK(bottom.width_from_search_box);
 	}
+}
+
+// Toggle icon-size source (ui-contract §1, FR-001/002/003/012/013): the toggle
+// inherits the category icon size in a sidebar, the search-bar height in the
+// search-bar row, and is unsized (0 → not applied) when hidden.
+void toggle_icon_size_source()
+{
+	const int category_px = 48;   // e.g. /category-icon-size == Normal
+	const int search_bar_px = 22; // e.g. measured from the search entry
+
+	CHECK(meow_toggle_icon_px(SwitchLocation::InSidebar, category_px, search_bar_px)
+			== category_px);
+	CHECK(meow_toggle_icon_px(SwitchLocation::InSearchBar, category_px, search_bar_px)
+			== search_bar_px);
+	CHECK(meow_toggle_icon_px(SwitchLocation::None, category_px, search_bar_px)
+			== 0);   // hidden — no size applied
 }
 
 // T038: the single label-visibility decision is identical for Apps and Places
@@ -209,6 +230,7 @@ int main()
 	fr029_reversion();
 	parse_positions();
 	strip_geometry_ordering();
+	toggle_icon_size_source();
 	label_visibility_decision();
 
 	if (g_failures != 0)


### PR DESCRIPTION
Crazy amount of bug-fixing after the new features of 0.6.0:

# Main Fixes
- Places: fix use-after-free when activating a search result — item is now opened before the menu closes.
- Places: extend the same lifetime fix to context-menu actions (Open, Open Containing, Open in Terminal, Open With).
- Places: open failures now show a single dialog naming the item and including the system error reason; blank/discarded errors are gone.
- Places: shell-quote paths passed to the external file-manager and terminal helper, fixing names with spaces, quotes, or $(...).
- Preset: fresh installs now reliably land on the Modern preset; the old property-count heuristic was fragile and could misdetect a first run as an upgrade on both dev and packaged installs
- Preset: Properties → General preset field is never blank; when the active layout matches no preset or the identity is unset, the field shows "Custom"
- Dev: dev-uninstall.sh now clears the plugin's full Xfconf state (including the new /initialized marker) so a reinstall is always detected as a genuine fresh install
- Dev: development tooling (dev-install.sh, dev-uninstall.sh, and the maintainer notes) is consolidated under dev/
- Sidebar: fix weird FullScree behaviour when SideBar is off
- Sidebar: fix sidebar width when it's horizontal in docked style presets

# Known Issues
- horizontal sidebar in FullScreen mode is not as wide as the search bar
- Selecting one Presets, changing something from properties and than moving to another Preset makes some of the custom changes persistent to the new Preset. "Reset to default" is a good workaround at the moment
