### PR TITLE
Release 0.6.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,18 @@
 MEOW MENU DEVELOPMENT
+0.6.2 (2026-06-XX)
+=====
+- Fixed: setting Profile Position or Commands Position to "Hidden" now actually hides the avatar/username or session buttons in the menu (was stored but never applied).
+- Fixed: when both Profile and Commands are set to "Hidden" in a docked layout, the entire user/session row collapses instead of leaving an empty strip.
+- Fixed: Full-Screen opacity slider now applies live without restarting the panel.
+- Fixed: Full-screen opacity now governs the entire menu surface, including the results/applications area (previously only the background was affected).
+- Fixed: App-box opacity now reaches true full transparency at 0; there is no longer a minimum floor below which the slider has no effect.
+- Fixed: All opacity controls (sidebar, app-box, full-screen) now honor a consistent 0 = fully transparent / 100 = fully solid contract.
+- Fixed: In docked mode, setting app-box opacity to 0 no longer lets the categories/sidebar region bleed through as a solid floor behind the results area.
+- Removed: "Show item metadata" toggle from the Places preferences tab — the option was stored but never used.
+- Removed: redundant "Bottom Right" option from the Profile Position dropdown (it rendered identically to "Bottom"); Commands Position retains it as it is distinct there.
+- Removed: orphaned grid layout settings (auto-size, columns, rows) that were stored but had no effect.
+- Migration: upgrading from a previous configuration automatically cleans the stored keys for all removed settings and rewrites "bottom-right" profile position to "bottom" (schema v6).
+
 0.6.1 (2026-06-05)
 =====
 - Places: fix use-after-free when activating a search result — item is now opened before the menu closes.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 MEOW MENU DEVELOPMENT
-0.6.2 (2026-06-XX)
+0.6.2 (2026-06-08)
 =====
 - Fixed: setting Profile Position or Commands Position to "Hidden" now actually hides the avatar/username or session buttons in the menu (was stored but never applied).
 - Fixed: when both Profile and Commands are set to "Hidden" in a docked layout, the entire user/session row collapses instead of leaving an empty strip.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,30 @@ All MeowMenu settings are exposed in the **Properties** dialog
 | Show user profile picture | Display the account avatar at the top of the menu. |
 | Show username | Display the logged-in user's name. |
 | Profile position | Where the profile block appears: top, bottom, or hidden. **Hidden** removes the avatar and username (and keeps them out of keyboard focus). |
-| Session commands position | Where the lock/logout/suspend buttons appear: top-right, bottom-right, or hidden. **Hidden** removes the session buttons. When both Profile and Session commands are hidden, the whole row collapses (the shared search row is kept in Full Screen). |
+| Session commands position | Where the lock/logout/suspend buttons appear: top-right, bottom-right, or hidden. **Hidden** removes the session buttons. |
+
+Profile and Session commands are **independent**: hiding one always keeps the
+other on its own side (profile on the left, session buttons on the right),
+regardless of where the category list sits. The row collapses only when **both**
+are hidden. **Hidden is fully reversible** — switching a hidden element back to a
+visible position restores it (and the row, if it had collapsed) immediately, with
+no restart and no need to reset to defaults.
+
+The two positions are **coupled** so the row always stays coherent:
+
+* **Docked layout** — the Session commands edge follows the Profile edge.
+  Choosing Profile = *Top* makes Session commands = *Top Right* (and *Bottom
+  Right* is greyed out); Profile = *Bottom* makes Session commands = *Bottom
+  Right*. When Profile is *Hidden* both Session-commands edges are available.
+* **Full Screen layout** — both Profile and Session commands follow the
+  **search bar** edge. With the search bar on top, both sit on the top edge (the
+  bottom options are greyed); moving the search bar to the bottom moves both with
+  it. Hiding both leaves only the centred search bar, at exactly the same size and
+  position as when they are shown.
+
+Disallowed edges are shown greyed rather than removed, and if a stored
+combination is no longer valid for the current layout it is automatically snapped
+to the nearest coherent edge (the element stays visible — only its edge moves).
 | Lock screen command | Command run when the lock button is clicked. |
 | Log out command | Command run when the log out button is clicked. |
 | Suspend command | Command run when the suspend button is clicked. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ All MeowMenu settings are exposed in the **Properties** dialog
 | Layout mode | **Docked** (standard panel-attached window) or **FullScreen** (full-screen launcher). |
 | Menu width | Width of the menu window in pixels. |
 | Menu height | Height of the menu window in pixels. |
-| Full-screen opacity | Opacity of the full-screen menu background (0–100), applied live. |
+| Full-screen opacity | Opacity of the entire full-screen menu, including the results area (0–100, where 0 is fully transparent and 100 fully solid), applied live. |
 | Stay visible when focus is lost | Keep the menu open when another window receives focus. |
 | Show panel button title | Display a text label next to the panel button icon. |
 | Panel button title | The label text shown on the panel button. |
@@ -125,9 +125,9 @@ Replace `<id>` with the numeric plugin ID shown by
 | `panel-gap` | int | 0 | Gap between the panel and the menu window. |
 | `menu-width` | int | 450 | Menu window width in pixels. |
 | `menu-height` | int | 500 | Menu window height in pixels. |
-| `categories-opacity` | int | 100 | Sidebar opacity (0–100). |
-| `apps-opacity` | int | 100 | Results area opacity (0–100). |
-| `full-screen-opacity` | int | 100 | Full-screen menu background opacity (0–100), applied live. |
+| `categories-opacity` | int | 100 | Sidebar opacity in docked mode (0 = fully transparent, 100 = fully solid). |
+| `apps-opacity` | int | 100 | Results area opacity in docked mode (0 = fully transparent, 100 = fully solid). |
+| `full-screen-opacity` | int | 100 | Opacity of the whole full-screen menu, results area included (0 = fully transparent, 100 = fully solid), applied live. |
 | `stay-on-focus-out` | bool | false | Keep menu open when focus moves away. |
 
 ### Layout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ All MeowMenu settings are exposed in the **Properties** dialog
 | Layout mode | **Docked** (standard panel-attached window) or **FullScreen** (full-screen launcher). |
 | Menu width | Width of the menu window in pixels. |
 | Menu height | Height of the menu window in pixels. |
-| Full-screen opacity | Opacity of the full-screen overlay (0–100). |
+| Full-screen opacity | Opacity of the full-screen menu background (0–100), applied live. |
 | Stay visible when focus is lost | Keep the menu open when another window receives focus. |
 | Show panel button title | Display a text label next to the panel button icon. |
 | Panel button title | The label text shown on the panel button. |
@@ -33,8 +33,8 @@ All MeowMenu settings are exposed in the **Properties** dialog
 |--------|-------------|
 | Show user profile picture | Display the account avatar at the top of the menu. |
 | Show username | Display the logged-in user's name. |
-| Profile position | Where the profile block appears: top, bottom, bottom-right, or hidden. |
-| Session commands position | Where the lock/logout/suspend buttons appear: top-right, bottom-right, or hidden. |
+| Profile position | Where the profile block appears: top, bottom, or hidden. **Hidden** removes the avatar and username (and keeps them out of keyboard focus). |
+| Session commands position | Where the lock/logout/suspend buttons appear: top-right, bottom-right, or hidden. **Hidden** removes the session buttons. When both Profile and Session commands are hidden, the whole row collapses (the shared search row is kept in Full Screen). |
 | Lock screen command | Command run when the lock button is clicked. |
 | Log out command | Command run when the log out button is clicked. |
 | Suspend command | Command run when the suspend button is clicked. |
@@ -91,7 +91,6 @@ All MeowMenu settings are exposed in the **Properties** dialog
 | Bookmark sync | Keep the Places bookmarks in sync with **MeowMenu** or **Thunar**. |
 | Max items | Maximum number of items shown in the Places view. |
 | Remember last mode | Reopen MeowMenu showing the last-used Places sub-section. |
-| Show metadata | Display file size and modification date next to each item. |
 
 #### Missing recent files and bookmarks
 
@@ -128,7 +127,7 @@ Replace `<id>` with the numeric plugin ID shown by
 | `menu-height` | int | 500 | Menu window height in pixels. |
 | `categories-opacity` | int | 100 | Sidebar opacity (0–100). |
 | `apps-opacity` | int | 100 | Results area opacity (0–100). |
-| `full-screen-opacity` | int | 100 | Full-screen overlay opacity (0–100). |
+| `full-screen-opacity` | int | 100 | Full-screen menu background opacity (0–100), applied live. |
 | `stay-on-focus-out` | bool | false | Keep menu open when focus moves away. |
 
 ### Layout
@@ -138,7 +137,7 @@ Replace `<id>` with the numeric plugin ID shown by
 | `layout-mode` | string | `docked` | `docked` or `fullscreen`. |
 | `sidebar-position` | string | `left` | `left`, `right`, `top`, or `bottom`. (A legacy `hidden` value is migrated to `sidebar-enabled = false`.) |
 | `search-bar-position` | string | `top` | `top` or `bottom`. |
-| `profile-position` | string | `top` | `top`, `bottom`, `bottom-right`, or `hidden`. |
+| `profile-position` | string | `top` | `top`, `bottom`, or `hidden`. (A legacy `bottom-right` value is migrated to `bottom`.) |
 | `commands-position` | string | `top-right` | `top-right`, `bottom-right`, or `hidden`. |
 | `unified-bar` | bool | false | Merge profile, search, and session into one row (FullScreen only). |
 
@@ -152,8 +151,6 @@ Replace `<id>` with the numeric plugin ID shown by
 | `launcher-show-tooltip` | bool | true | Show a hover tooltip. |
 | `launcher-icon-size` | int | -1 | Icon size (-1 = theme default). |
 | `grid-density` | string | `medium` | `low`, `medium`, or `high` columns in grid mode. |
-| `grid-columns` | int | 4 | Explicit column count for grid mode. |
-| `grid-rows` | int | 3 | Visible rows in grid mode. |
 
 ### Sidebar
 
@@ -189,4 +186,3 @@ Replace `<id>` with the numeric plugin ID shown by
 | `places/favourite-sync` | string | `meowmenu` | Keep bookmarks in sync with `meowmenu` or `thunar`. |
 | `places/max-items` | int | 20 | Maximum items in the Places view. |
 | `places/remember-last-mode` | bool | false | Reopen in the last-used Places sub-section. |
-| `places/show-metadata` | bool | false | Show file size and modification date. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Replace `<id>` with the numeric plugin ID shown by
 
 | Key (relative to `/plugins/<id>/`) | Type | Default | Description |
 |------------------------------------|------|---------|-------------|
-| `corner-radius` | int | 0 | Menu window corner radius in pixels. |
+| `corner-radius` | int | 0 | Radius, in pixels, that rounds the menu's visible outer corners (0 = square). |
 | `panel-gap` | int | 0 | Gap between the panel and the menu window. |
 | `menu-width` | int | 450 | Menu window width in pixels. |
 | `menu-height` | int | 500 | Menu window height in pixels. |

--- a/panel-plugin/core/opacity-model.cpp
+++ b/panel-plugin/core/opacity-model.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "opacity-model.h"
+
+/* meowmenu_opacity_alpha:
+ * Linear, clamped percentage->alpha map. Kept separate so the renderer and the
+ * unit test share one definition of the endpoint contract.
+ */
+double meowmenu_opacity_alpha(int value)
+{
+	if (value <= 0)
+		return 0.0;
+	if (value >= 100)
+		return 1.0;
+	return value / 100.0;
+}
+
+/* meowmenu_region_alphas:
+ * Implements the two complementary single-alpha models so no region ever
+ * carries two backgrounds that compound:
+ *   - Full-screen: the window shell owns the one full-screen alpha; the
+ *     categories and applications regions paint nothing (transparent), so the
+ *     whole surface — results area included — reads at exactly alpha(full).
+ *   - Docked: the window shell paints nothing; the categories region and the
+ *     applications region each own their absolute alpha over the transparent
+ *     window, so apps_opacity can reach a true 0 with no categories floor
+ *     showing through underneath.
+ */
+OpacityRegionAlphas meowmenu_region_alphas(bool fullscreen,
+                                           int categories_opacity,
+                                           int apps_opacity,
+                                           int full_screen_opacity)
+{
+	OpacityRegionAlphas result;
+	if (fullscreen)
+	{
+		result.window = meowmenu_opacity_alpha(full_screen_opacity);
+		result.categories = 0.0;
+		result.apps = 0.0;
+	}
+	else
+	{
+		result.window = 0.0;
+		result.categories = meowmenu_opacity_alpha(categories_opacity);
+		result.apps = meowmenu_opacity_alpha(apps_opacity);
+	}
+	return result;
+}

--- a/panel-plugin/core/opacity-model.h
+++ b/panel-plugin/core/opacity-model.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEOWMENU_CORE_OPACITY_MODEL_H
+#define MEOWMENU_CORE_OPACITY_MODEL_H
+
+/*
+ * Pure, GTK-free model for the menu's three opacity controls.
+ *
+ * Rendering contract (0 = fully transparent, 100 = fully solid):
+ *   - Each control is an integer percentage in [0, 100].
+ *   - alpha = clamp(value, 0, 100) / 100.0, so 0 -> 0.0 and 100 -> 1.0,
+ *     strictly monotonic with no internal floor or ceiling (no dead zone).
+ *   - A region's visible alpha is exactly the alpha of its single governing
+ *     control. Regions never compound: the renderer must not place one opaque
+ *     background behind another so the two combine into 1-(1-a)(1-b).
+ *
+ * This translation unit deliberately includes no GTK headers so the contract
+ * can be unit-tested headlessly, mirroring the sidebar-layout / window-size-clamp
+ * helpers.
+ */
+
+/* The single alpha assigned to each menu surface region for one render pass. */
+struct OpacityRegionAlphas
+{
+	double window;     /* the .meowmenu window shell background */
+	double categories; /* the sidebar/categories region (and its chrome strips) */
+	double apps;       /* the results / applications area */
+};
+
+/* meowmenu_opacity_alpha:
+ * @value: an opacity percentage; values outside [0, 100] are clamped.
+ *
+ * Maps a stored opacity percentage to a CSS alpha in [0.0, 1.0] as
+ * clamp(value, 0, 100) / 100.0.
+ *
+ * Returns: the alpha; 0.0 at value <= 0, 1.0 at value >= 100.
+ */
+double meowmenu_opacity_alpha(int value);
+
+/* meowmenu_region_alphas:
+ * @fullscreen: true when the menu is in full-screen layout mode.
+ * @categories_opacity: the sidebar/categories control value (docked only).
+ * @apps_opacity: the results-area control value (docked only).
+ * @full_screen_opacity: the single full-screen control value (full-screen only).
+ *
+ * Resolves which absolute alpha each region receives so that exactly one
+ * control governs any given region (no inter-region compounding). In
+ * full-screen the window shell owns the single full-screen alpha and the
+ * regions are transparent; in docked mode the window shell is transparent and
+ * each region owns its own absolute alpha.
+ *
+ * Returns: the per-region alphas for this render pass.
+ */
+OpacityRegionAlphas meowmenu_region_alphas(bool fullscreen,
+                                           int categories_opacity,
+                                           int apps_opacity,
+                                           int full_screen_opacity);
+
+#endif // MEOWMENU_CORE_OPACITY_MODEL_H

--- a/panel-plugin/core/user-session-layout.cpp
+++ b/panel-plugin/core/user-session-layout.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/user-session-layout.h"
+
+#include <cstring>
+
+using namespace WhiskerMenu;
+
+namespace
+{
+
+// Canonical position literals. The resolution returns pointers into these so
+// the result owns no memory and every value is comparable by identity or value.
+const char* const PROFILE_TOP     = "top";
+const char* const PROFILE_BOTTOM  = "bottom";
+const char* const PROFILE_HIDDEN  = "hidden";
+const char* const COMMANDS_TOP    = "top-right";
+const char* const COMMANDS_BOTTOM = "bottom-right";
+const char* const COMMANDS_HIDDEN = "hidden";
+
+bool str_eq(const char* a, const char* b)
+{
+	return a && b && std::strcmp(a, b) == 0;
+}
+
+}
+
+/* normalize_user_session:
+ * See user-session-layout.h for the full contract. The body is a direct
+ * transcription of the coupling-matrix rule tables: §A for Docked (Commands
+ * edge follows the Profile edge), §C for FullScreen (both edges follow the
+ * search-bar edge), §D for the snap direction. A "hidden" value is always
+ * carried through untouched and its *_hidden_enabled mask is always true.
+ */
+UserSessionResolution
+WhiskerMenu::normalize_user_session(LayoutMode mode, const char* search_bar_pos,
+                                    const char* profile_pos, const char* commands_pos)
+{
+	// Defensive canonicalisation: missing/unknown inputs fall back to the
+	// schema defaults so the function is total over its declared domain.
+	const bool profile_hidden  = str_eq(profile_pos, PROFILE_HIDDEN);
+	const bool commands_hidden = str_eq(commands_pos, COMMANDS_HIDDEN);
+	const bool profile_bottom_in  = str_eq(profile_pos, PROFILE_BOTTOM);
+	const bool commands_bottom_in = str_eq(commands_pos, COMMANDS_BOTTOM);
+	const bool search_bottom = str_eq(search_bar_pos, PROFILE_BOTTOM);
+
+	UserSessionResolution r;
+	// Hidden is never produced by coupling, so it is always a legal choice.
+	r.profile_hidden_enabled  = true;
+	r.commands_hidden_enabled = true;
+	r.profile_changed  = false;
+	r.commands_changed = false;
+
+	if (mode == LayoutMode::Docked)
+	{
+		// §A: Profile is a free choice; Commands edge is coupled to it.
+		r.profile_top_enabled    = true;
+		r.profile_bottom_enabled = true;
+
+		if (profile_hidden)
+		{
+			// Profile hidden frees both Commands edges (no governing edge).
+			r.profile_position = PROFILE_HIDDEN;
+			r.commands_top_right_enabled    = true;
+			r.commands_bottom_right_enabled = true;
+			r.commands_position = commands_hidden
+					? COMMANDS_HIDDEN
+					: (commands_bottom_in ? COMMANDS_BOTTOM : COMMANDS_TOP);
+		}
+		else
+		{
+			// Profile drives the governing edge; the opposite Commands edge is
+			// greyed and any visible value on it snaps toward the Profile edge.
+			r.profile_position = profile_bottom_in ? PROFILE_BOTTOM : PROFILE_TOP;
+			r.commands_top_right_enabled    = !profile_bottom_in;
+			r.commands_bottom_right_enabled =  profile_bottom_in;
+
+			if (commands_hidden)
+			{
+				r.commands_position = COMMANDS_HIDDEN;
+			}
+			else
+			{
+				r.commands_position = profile_bottom_in ? COMMANDS_BOTTOM : COMMANDS_TOP;
+				r.commands_changed =
+						(profile_bottom_in != commands_bottom_in);
+			}
+		}
+	}
+	else
+	{
+		// §C: both Profile and Commands edges follow the search-bar edge; only
+		// the visible-vs-hidden choice is free.
+		r.profile_top_enabled    = !search_bottom;
+		r.profile_bottom_enabled =  search_bottom;
+		r.commands_top_right_enabled    = !search_bottom;
+		r.commands_bottom_right_enabled =  search_bottom;
+
+		if (profile_hidden)
+		{
+			r.profile_position = PROFILE_HIDDEN;
+		}
+		else
+		{
+			r.profile_position = search_bottom ? PROFILE_BOTTOM : PROFILE_TOP;
+			r.profile_changed = (search_bottom != profile_bottom_in);
+		}
+
+		if (commands_hidden)
+		{
+			r.commands_position = COMMANDS_HIDDEN;
+		}
+		else
+		{
+			r.commands_position = search_bottom ? COMMANDS_BOTTOM : COMMANDS_TOP;
+			r.commands_changed = (search_bottom != commands_bottom_in);
+		}
+	}
+
+	return r;
+}

--- a/panel-plugin/core/user-session-layout.h
+++ b/panel-plugin/core/user-session-layout.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WHISKERMENU_USER_SESSION_LAYOUT_H
+#define WHISKERMENU_USER_SESSION_LAYOUT_H
+
+namespace WhiskerMenu
+{
+
+// Which window layout governs the Profile/Commands edge coupling. Derived from
+// the /layout-mode key: "docked" → Docked, "fullscreen" → FullScreen.
+enum class LayoutMode
+{
+	Docked,
+	FullScreen
+};
+
+// Outcome of resolving a (profile_position, commands_position) pair against the
+// active layout's coupling rule. Holds both the coherent values to render and
+// (when changed) to persist, and the per-option enabled masks the Preferences
+// combos use to grey disallowed — but still listed — options.
+struct UserSessionResolution
+{
+	// Resolved, coupling-valid values. Pointers into static string literals
+	// ("top" | "bottom" | "hidden", "top-right" | "bottom-right" | "hidden");
+	// never NULL, never owned by the caller.
+	const char* profile_position;
+	const char* commands_position;
+
+	// Per-option combo sensitivity (greyed, not removed — FR-010). The two
+	// *_hidden_enabled masks are always true: visibility is only ever changed
+	// by the user, never forced by coupling.
+	bool profile_top_enabled;
+	bool profile_bottom_enabled;
+	bool profile_hidden_enabled;
+	bool commands_top_right_enabled;
+	bool commands_bottom_right_enabled;
+	bool commands_hidden_enabled;
+
+	// True when the resolved value differs from the corresponding input, i.e.
+	// the caller snapped a disallowed edge and must persist the new value so the
+	// stored configuration and the rendered row stay in sync (FR-014/FR-017).
+	bool profile_changed;
+	bool commands_changed;
+};
+
+/* normalize_user_session:
+ * @mode:           Docked or FullScreen (from /layout-mode).
+ * @search_bar_pos: "top" | "bottom"; governs both edges in FullScreen, ignored
+ *                  in Docked. NULL is treated as "top".
+ * @profile_pos:    stored "top" | "bottom" | "hidden". NULL is treated as "top".
+ * @commands_pos:   stored "top-right" | "bottom-right" | "hidden". NULL is
+ *                  treated as "top-right".
+ *
+ * Pure decision: depends only on the four inputs, reads no Xfconf, touches no
+ * widget, holds no state. Resolves any coupling-invalid edge toward the
+ * governing edge (the Profile edge in Docked, the search-bar edge in
+ * FullScreen) without ever turning a visible component "hidden" and without
+ * ever un-hiding a "hidden" one; reports the per-option enabled masks for the
+ * dialog. Idempotent: feeding a resolved pair back in yields the same pair with
+ * both *_changed flags false.
+ *
+ * Returns: a UserSessionResolution by value. No allocation, no ownership
+ * transfer; the embedded const char* point at static literals.
+ */
+UserSessionResolution
+normalize_user_session(LayoutMode mode, const char* search_bar_pos,
+                       const char* profile_pos, const char* commands_pos);
+
+}
+
+#endif // WHISKERMENU_USER_SESSION_LAYOUT_H

--- a/panel-plugin/core/window-frame.cpp
+++ b/panel-plugin/core/window-frame.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "window-frame.h"
+
+namespace meow
+{
+
+// Supported corner-radius range. Mirrors the /corner-radius control range so
+// the visible rounding always tracks what the GUI can request.
+namespace
+{
+const int kMinCornerRadius = 0;
+const int kMaxCornerRadius = 24;
+} // namespace
+
+int meowmenu_clamp_corner_radius(int radius)
+{
+	if (radius < kMinCornerRadius)
+		return kMinCornerRadius;
+	if (radius > kMaxCornerRadius)
+		return kMaxCornerRadius;
+	return radius;
+}
+
+bool meowmenu_frame_draws_border(bool is_fullscreen, bool supports_alpha)
+{
+	// Full-screen reads as one seamless surface (no outline); the composited
+	// rounded stroke also needs an RGBA visual to be drawn at all.
+	return !is_fullscreen && supports_alpha;
+}
+
+} // namespace meow

--- a/panel-plugin/core/window-frame.h
+++ b/panel-plugin/core/window-frame.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 MeowMenu contributors
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEOWMENU_CORE_WINDOW_FRAME_H
+#define MEOWMENU_CORE_WINDOW_FRAME_H
+
+namespace meow
+{
+
+/* meowmenu_clamp_corner_radius:
+ * @radius: a requested corner radius in logical pixels (may be out of range).
+ *
+ * Clamps the requested radius into the supported window-frame range [0, 24].
+ * This is the single source of truth shared by the draw path (which builds the
+ * rounded clip) and the live property-changed handler, so the visible rounding
+ * can never diverge from the control's range. The mapping is monotonic: a
+ * larger in-range request never yields a smaller result.
+ *
+ * Returns: the clamped radius, always in [0, 24].
+ */
+int meowmenu_clamp_corner_radius(int radius);
+
+/* meowmenu_frame_draws_border:
+ * @is_fullscreen: true when the menu is in full-screen layout.
+ * @supports_alpha: true when an RGBA visual / compositor is available.
+ *
+ * Decides whether the single rounded, composited border stroke is emitted.
+ * It is drawn only for the docked, composited case: a full-screen menu reads as
+ * one seamless surface (no outline), and without a compositor the rounded path
+ * cannot be drawn. The non-composited docked square-border fallback is NOT this
+ * predicate — that case is handled separately under its own !is_fullscreen
+ * guard in the draw fallback.
+ *
+ * Returns: true iff (!is_fullscreen && supports_alpha).
+ */
+bool meowmenu_frame_draws_border(bool is_fullscreen, bool supports_alpha);
+
+} // namespace meow
+
+#endif // MEOWMENU_CORE_WINDOW_FRAME_H

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -30,6 +30,7 @@
 #include "profile.h"
 #include "launcher/recent-page.h"
 #include "resizer.h"
+#include "opacity-model.h"
 #include "search/search-page.h"
 #include "settings.h"
 #include "sidebar-layout.h"
@@ -876,7 +877,8 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 			{
 				if (g_strcmp0(property, "/corner-radius") != 0
 						&& g_strcmp0(property, "/categories-opacity") != 0
-						&& g_strcmp0(property, "/apps-opacity") != 0)
+						&& g_strcmp0(property, "/apps-opacity") != 0
+						&& g_strcmp0(property, "/full-screen-opacity") != 0)
 					return;
 				auto* self = static_cast<Window*>(user_data);
 				if (g_strcmp0(property, "/corner-radius") == 0 && self->m_frame)
@@ -1991,20 +1993,6 @@ void WhiskerMenu::Window::update_background_css()
 		bg_found = gtk_style_context_lookup_color(context, "bg_color", &bg);
 	}
 
-	// TEMPORARY DIAGNOSTIC — remove before merge
-	{
-		gchar* theme = nullptr;
-		gboolean prefer_dark = FALSE;
-		g_object_get(gtk_settings_get_default(),
-			"gtk-theme-name", &theme,
-			"gtk-application-prefer-dark-theme", &prefer_dark, nullptr);
-		gboolean realized = gtk_widget_get_realized(GTK_WIDGET(m_window));
-		g_message("update_background_css: theme=%s prefer_dark=%d realized=%d bg_found=%d bg=rgb(%d,%d,%d)",
-			theme ? theme : "(null)", (int)prefer_dark, (int)realized, (int)bg_found,
-			(int)(bg.red * 255 + 0.5), (int)(bg.green * 255 + 0.5), (int)(bg.blue * 255 + 0.5));
-		g_free(theme);
-	}
-
 	if (!bg_found)
 	{
 		// Both background lookups failed. The old code kept the unconditional
@@ -2029,19 +2017,49 @@ void WhiskerMenu::Window::update_background_css()
 	const int red   = CLAMP(static_cast<int>(bg.red   * 255.0 + 0.5), 0, 255);
 	const int green = CLAMP(static_cast<int>(bg.green * 255.0 + 0.5), 0, 255);
 	const int blue  = CLAMP(static_cast<int>(bg.blue  * 255.0 + 0.5), 0, 255);
-	const double cats_alpha = CLAMP(m_settings->categories_opacity, 0, 100) / 100.0;
-	const double apps_alpha = CLAMP(m_settings->apps_opacity, 0, 100) / 100.0;
-	// In full-screen the whole menu window carries its own opacity control;
-	// docked layouts keep the categories opacity for the window background. The
-	// alpha is built exactly like cats_alpha/apps_alpha so the live reload path
-	// is shared.
+	// Separator colour for the docked results-area outline. The docked window
+	// shell is fully transparent (so apps-opacity 0 reaches true transparency),
+	// which means the inter-region gaps the window background used to fill are
+	// no longer painted. The visible boundaries all sit around the results area,
+	// so a single opaque 1 px outline owned by that region restores them without
+	// putting any paint behind it. Nudge the seed toward or away from black by a
+	// fixed step depending on the theme's lightness so the line reads on both
+	// dark and light themes.
+	const double sep_luma = 0.299 * red + 0.587 * green + 0.114 * blue;
+	const int sep_step = 45;
+	const int sep_r = (sep_luma < 128.0) ? CLAMP(red   + sep_step, 0, 255) : CLAMP(red   - sep_step, 0, 255);
+	const int sep_g = (sep_luma < 128.0) ? CLAMP(green + sep_step, 0, 255) : CLAMP(green - sep_step, 0, 255);
+	const int sep_b = (sep_luma < 128.0) ? CLAMP(blue  + sep_step, 0, 255) : CLAMP(blue  - sep_step, 0, 255);
+	// Resolve which absolute alpha each region receives for this render pass.
+	// The pure helper enforces the 0=transparent / 100=solid contract and the
+	// dual single-alpha model: docked => transparent window with each region
+	// owning its alpha (so apps-opacity 0 reaches true transparency with no
+	// categories floor showing through); full-screen => the window shell owns
+	// the one full-screen alpha and the regions are transparent (so the whole
+	// surface, results area included, reads at exactly that one value). Neither
+	// mode lets two backgrounds compound.
 	const bool is_fullscreen = (g_strcmp0(m_settings->layout_mode, "fullscreen") == 0);
-	const double window_alpha = is_fullscreen
-			? CLAMP(m_settings->full_screen_opacity, 0, 100) / 100.0
-			: cats_alpha;
+	const OpacityRegionAlphas alphas = meowmenu_region_alphas(
+			is_fullscreen,
+			m_settings->categories_opacity,
+			m_settings->apps_opacity,
+			m_settings->full_screen_opacity);
+
+	// The results outline only applies in docked mode. In full-screen the whole
+	// surface carries one alpha and the regions are transparent, so an outline
+	// there would draw a stray rectangle over an intentionally seamless menu.
+	gchar* apps_border = is_fullscreen
+			? g_strdup("")
+			: g_strdup_printf(
+				".meowmenu .applications-area"
+				"{ border: 1px solid rgba(%d, %d, %d, 1.0); }",
+				sep_r, sep_g, sep_b);
 
 	gchar* css = g_strdup_printf(
 		".meowmenu { background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
+		// NOTE: .contents stays transparent on purpose — it is an ancestor of
+		// the applications area, so giving it a background would re-introduce a
+		// solid floor under the results region and defeat true-0 apps opacity.
 		".meowmenu > *,"
 		".meowmenu frame,"
 		".meowmenu frame > *,"
@@ -2051,21 +2069,28 @@ void WhiskerMenu::Window::update_background_css()
 		".meowmenu scrolledwindow > *,"
 		".meowmenu grid,"
 		".meowmenu grid > *,"
-		".meowmenu .search-area,"
-		".meowmenu .title-area,"
-		".meowmenu .commands-area,"
 		".meowmenu .contents,"
 		".meowmenu .contents > *,"
-		".meowmenu .categories,"
 		".meowmenu treeview,"
 		".meowmenu flowbox,"
 		".meowmenu flowboxchild,"
 		".meowmenu list,"
 		".meowmenu row"
 		"{ background-color: transparent; background-image: none; }"
+		// Sidebar/categories region plus the chrome strips (search, title,
+		// commands bars) share one absolute alpha so the menu frame stays
+		// cohesive. In full-screen this alpha is 0 (transparent) so only the
+		// window shell carries the single full-screen opacity.
+		".meowmenu .categories,"
+		".meowmenu .search-area,"
+		".meowmenu .title-area,"
+		".meowmenu .commands-area"
+		"{ background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
 		".meowmenu .applications-area,"
 		".meowmenu .applications-area > *"
 		"{ background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
+		// Docked-only crisp 1 px results outline (empty string in full-screen).
+		"%s"
 		".meowmenu .category-button,"
 		".meowmenu .category-button *,"
 		".meowmenu .category-button image,"
@@ -2089,11 +2114,14 @@ void WhiskerMenu::Window::update_background_css()
 		".meowmenu treeview:focus-visible,"
 		".meowmenu iconview:focus-visible"
 		"{ outline: 1px solid @theme_selected_bg_color; outline-offset: -1px; }",
-		red, green, blue, window_alpha,
-		red, green, blue, apps_alpha);
+		red, green, blue, alphas.window,
+		red, green, blue, alphas.categories,
+		red, green, blue, alphas.apps,
+		apps_border);
 
 	gtk_css_provider_load_from_data(m_css_provider, css, -1, nullptr);
 	g_free(css);
+	g_free(apps_border);
 }
 
 //-----------------------------------------------------------------------------
@@ -2737,6 +2765,15 @@ void WhiskerMenu::Window::update_layout()
 	gtk_widget_set_margin_bottom(GTK_WIDGET(m_categories_box),
 			m_layout_categories_horizontal && strip_below_results ? STRIP_GAP : 0);
 
+	// Docked mode paints a transparent window shell, so any spacing between
+	// regions would be a transparent band rather than the frame grey the window
+	// background used to supply. Collapse the inter-region spacing to 0 in docked
+	// mode and let the results-area outline (update_background_css) draw the
+	// boundaries; full-screen keeps the 6 px rhythm because its single window
+	// alpha fills the gaps and the centring math depends on the column gap.
+	const bool docked = !layout_state.fullscreen;
+	gtk_box_set_spacing(m_vbox, docked ? 0 : 6);
+
 	gtk_grid_remove_row(m_contents_box, 1);
 	gtk_grid_remove_row(m_contents_box, 0);
 	if (m_layout_categories_horizontal)
@@ -2748,7 +2785,7 @@ void WhiskerMenu::Window::update_layout()
 	}
 	else
 	{
-		gtk_grid_set_column_spacing(m_contents_box, 6);
+		gtk_grid_set_column_spacing(m_contents_box, docked ? 0 : 6);
 		gtk_grid_set_row_spacing(m_contents_box, 0);
 
 		gtk_style_context_add_class(context, (m_layout_ltr == m_layout_categories_alternate) ? "left" : "right");

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -35,6 +35,7 @@
 #include "settings.h"
 #include "sidebar-layout.h"
 #include "theme-fallback.h"
+#include "user-session-layout.h"
 #include "ui/slot.h"
 #include "ui/switch-icons.h"
 #include "search/unified-bar.h"
@@ -196,6 +197,8 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 	m_layout_search_alternate(false),
 	m_layout_commands_alternate(false),
 	m_layout_profile_alternate(false),
+	m_layout_profile_hidden(false),
+	m_layout_commands_hidden(false),
 	m_layout_unified_bar(false),
 	m_profile_shape(0),
 	m_supports_alpha(false),
@@ -1177,6 +1180,12 @@ void WhiskerMenu::Window::show(const Position position)
 	const bool commands_alt = (g_strcmp0(commands_pos, "bottom-right") == 0)
 			|| (g_strcmp0(commands_pos, "top-right") != 0 && g_strcmp0(commands_pos, "hidden") != 0
 				&& m_settings->position_commands_alternate);
+	// NOTE: hidden state is tracked independently of the edge flags above. A
+	// Hidden ↔ visible transition (e.g. "hidden" → "top") leaves *_alternate
+	// unchanged, so without these comparisons show() would skip update_layout()
+	// and the restored element would never re-render (defect 2, FR-005/006).
+	const bool profile_hidden  = (g_strcmp0(profile_pos, "hidden") == 0);
+	const bool commands_hidden = (g_strcmp0(commands_pos, "hidden") == 0);
 
 	// NOTE: schema v2 — horizontal-categories is derived from sidebar-position
 	// (top|bottom); the legacy /position-categories-horizontal key is migrated
@@ -1207,6 +1216,8 @@ void WhiskerMenu::Window::show(const Position position)
 			|| (m_layout_search_alternate != search_alt)
 			|| (m_layout_commands_alternate != commands_alt)
 			|| (m_layout_profile_alternate != profile_alt)
+			|| (m_layout_profile_hidden != profile_hidden)
+			|| (m_layout_commands_hidden != commands_hidden)
 			|| (m_layout_unified_bar != unified_eff)
 			|| (m_profile_shape != m_settings->profile_shape))
 	{
@@ -1220,6 +1231,8 @@ void WhiskerMenu::Window::show(const Position position)
 		m_layout_search_alternate = search_alt;
 		m_layout_commands_alternate = commands_alt;
 		m_layout_profile_alternate = profile_alt;
+		m_layout_profile_hidden = profile_hidden;
+		m_layout_commands_hidden = commands_hidden;
 		m_profile->update_picture();
 		m_profile_shape = m_settings->profile_shape;
 		update_layout();
@@ -1460,27 +1473,28 @@ void WhiskerMenu::Window::unset_items()
  * @unified:              true when the unified search/profile/session bar is active.
  * @profile_hidden:       true when profile_position == "hidden".
  * @commands_hidden:      true when commands_position == "hidden".
- * @categories_alternate: true when the category list sits at the alternate (bottom) end.
+ * @categories_alternate: unused; retained for signature stability with the
+ *                        mirrored unit test.
  *
  * Pure visibility decision for the docked user/session row (m_title_box). In a
  * unified-bar / full-screen layout the row hosts the centred search cluster, so
  * it is always kept and only the profile/commands clusters hide (FR-004). In a
- * docked layout the row collapses entirely when both clusters are hidden so no
- * empty strip remains (FR-003); otherwise it follows the existing
- * bottom-categories suppression.
+ * docked layout the row is present whenever either cluster is visible and
+ * collapses only when both are hidden, so no empty strip remains (FR-003).
+ *
+ * NOTE: row visibility must NOT depend on category placement. The previous
+ * `return !categories_alternate` branch coupled the row's existence to where
+ * the category list sat, which suppressed a visible commands cluster whenever
+ * the categories were at the bottom (defect 1, FR-001).
  *
  * Returns: true if the user/session row should be visible.
  */
 static bool user_session_row_visible(bool unified, bool profile_hidden,
-                                     bool commands_hidden, bool categories_alternate)
+                                     bool commands_hidden, bool /*categories_alternate*/)
 {
 	if (unified)
 		return true;
-	if (!profile_hidden)
-		return true;
-	if (commands_hidden)
-		return false;
-	return !categories_alternate;
+	return !(profile_hidden && commands_hidden);
 }
 
 //-----------------------------------------------------------------------------
@@ -2653,20 +2667,50 @@ void WhiskerMenu::Window::update_layout()
 	// ProfileHidden shape is migrated to profile_position == "hidden" on upgrade
 	// and is no longer consulted here. The avatar + username follow the profile
 	// position; the whole session command box follows the commands position.
-	const bool profile_hidden  = (g_strcmp0(m_settings->profile_position, "hidden") == 0);
-	const bool commands_hidden = (g_strcmp0(m_settings->commands_position, "hidden") == 0);
 	const bool unified         = unified_bar_effective(*m_settings);
+
+	// Resolve the Profile/Commands pair through the shared coupling helper so the
+	// rendered row reflects a coherent edge combination — the same resolution the
+	// Preferences combos grey and prevent_invalid() persists (FR-014). A "hidden"
+	// value is always preserved by the helper, so the visibility decisions below
+	// are unchanged for hidden inputs; the edge resolution matters for the
+	// reorder/packing that follows. Full-screen coupling is finalised in the
+	// unified-bar packing further down.
+	const LayoutMode user_session_mode =
+			(g_strcmp0(m_settings->layout_mode, "fullscreen") == 0)
+			? LayoutMode::FullScreen : LayoutMode::Docked;
+	const UserSessionResolution user_session = normalize_user_session(
+			user_session_mode, m_settings->search_bar_position,
+			m_settings->profile_position, m_settings->commands_position);
+	const bool profile_hidden  = (g_strcmp0(user_session.profile_position, "hidden") == 0);
+	const bool commands_hidden = (g_strcmp0(user_session.commands_position, "hidden") == 0);
 
 	gtk_widget_set_visible(m_profile->get_picture(),  !profile_hidden);
 	gtk_widget_set_visible(m_profile->get_username(), !profile_hidden);
 	gtk_widget_set_visible(GTK_WIDGET(m_commands_box), !commands_hidden);
 
-	// Collapse the user/session row when both clusters are hidden in a docked
-	// layout (FR-003); keep it in unified-bar / full-screen where it carries the
-	// shared search row (FR-004).
+	// A bottom-right commands cluster is packed into the search row (the
+	// m_layout_commands_alternate branch above), not the user/session row, so it
+	// does not keep the title row alive on its own — only commands that share the
+	// title row count toward its visibility.
+	const bool commands_in_title_row = !commands_hidden && !m_layout_commands_alternate;
+
+	// Collapse the user/session row only when nothing remains in it (FR-003);
+	// keep it in unified-bar / full-screen where it carries the shared search row
+	// (FR-004). Independent of category placement (FR-001).
 	gtk_widget_set_visible(GTK_WIDGET(m_title_box),
-			user_session_row_visible(unified, profile_hidden, commands_hidden,
+			user_session_row_visible(unified, profile_hidden, !commands_in_title_row,
 					m_layout_categories_alternate));
+
+	// When the profile cluster is hidden, no expanding username remains in the
+	// title row to push the surviving commands cluster to the trailing edge, so
+	// give the commands box the expand + end alignment itself (FR-002). Reset to
+	// the neutral state otherwise; the unified bar handles its own right-edge
+	// placement via pack_end below.
+	const bool docked_solo_commands = commands_in_title_row && profile_hidden && !unified;
+	gtk_widget_set_hexpand(GTK_WIDGET(m_commands_box), docked_solo_commands);
+	gtk_widget_set_halign(GTK_WIDGET(m_commands_box),
+			docked_solo_commands ? GTK_ALIGN_END : GTK_ALIGN_FILL);
 
 	// Arrange horizontal order of profile picture, username, and commands
 	if (m_layout_ltr && m_layout_commands_alternate)
@@ -2927,6 +2971,14 @@ void WhiskerMenu::Window::update_layout()
 	// not overflow the app-grid boundary (sidebar_w + 6 + panels_stack + 6 + void
 	// == workarea, so each side effectively costs sidebar_w + 3; we subtract the
 	// full column gap once here to stay within the visual content column).
+	//
+	// NOTE: this width is computed purely from the workarea/sidebar geometry and
+	// is independent of whether the profile or commands clusters are visible, so
+	// hiding both (FR-013) leaves the centred search bar — and therefore the
+	// results grid and the left/right void widths — at exactly the same size and
+	// position as when both clusters are shown (SC-005, INV-4). The merged row
+	// reads profile + void + search bar + void + session via the centre widget;
+	// hiding a cluster only blanks that child, it never re-flows the geometry.
 	if (eff)
 	{
 		const int sidebar_w = (m_workarea.width > 0) ? m_workarea.width / 6 : 0;

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -1454,14 +1454,41 @@ void WhiskerMenu::Window::unset_items()
 
 //-----------------------------------------------------------------------------
 
+/* user_session_row_visible:
+ * @unified:              true when the unified search/profile/session bar is active.
+ * @profile_hidden:       true when profile_position == "hidden".
+ * @commands_hidden:      true when commands_position == "hidden".
+ * @categories_alternate: true when the category list sits at the alternate (bottom) end.
+ *
+ * Pure visibility decision for the docked user/session row (m_title_box). In a
+ * unified-bar / full-screen layout the row hosts the centred search cluster, so
+ * it is always kept and only the profile/commands clusters hide (FR-004). In a
+ * docked layout the row collapses entirely when both clusters are hidden so no
+ * empty strip remains (FR-003); otherwise it follows the existing
+ * bottom-categories suppression.
+ *
+ * Returns: true if the user/session row should be visible.
+ */
+static bool user_session_row_visible(bool unified, bool profile_hidden,
+                                     bool commands_hidden, bool categories_alternate)
+{
+	if (unified)
+		return true;
+	if (!profile_hidden)
+		return true;
+	if (commands_hidden)
+		return false;
+	return !categories_alternate;
+}
+
+//-----------------------------------------------------------------------------
+
 Keyboard::VisibilityMask WhiskerMenu::Window::current_visibility_mask() const
 {
 	// FR-030: Search and Results are never hidden. Optional zones follow
 	// the preset's per-zone "hidden" position string and the legacy
-	// visibility flags. Profile is the session-button row and is gated on
-	// commands_position != "hidden" with at least one visible command. The
-	// Apps/Places toggle is not a focus zone (FR-007), so it has no entry
-	// here; Tab reads places_enabled directly.
+	// visibility flags. The Apps/Places toggle is not a focus zone (FR-007),
+	// so it has no entry here; Tab reads places_enabled directly.
 	Keyboard::VisibilityMask mask;
 	mask.search  = true;
 	mask.results = true;
@@ -1471,6 +1498,11 @@ Keyboard::VisibilityMask WhiskerMenu::Window::current_visibility_mask() const
 
 	mask.sidebar = (g_strcmp0(sidebar_pos, "hidden") != 0);
 
+	// The "profile" focus zone is the session-command row: only the command
+	// buttons are focusable (the avatar/username are not), so a hidden profile
+	// contributes nothing focusable. The zone is therefore gated on
+	// commands_position != "hidden" with at least one visible command, which
+	// already keeps focus off both hidden commands and a hidden profile (FR-005).
 	bool any_command_visible = false;
 	if (g_strcmp0(commands_pos, "hidden") != 0)
 	{
@@ -1999,6 +2031,14 @@ void WhiskerMenu::Window::update_background_css()
 	const int blue  = CLAMP(static_cast<int>(bg.blue  * 255.0 + 0.5), 0, 255);
 	const double cats_alpha = CLAMP(m_settings->categories_opacity, 0, 100) / 100.0;
 	const double apps_alpha = CLAMP(m_settings->apps_opacity, 0, 100) / 100.0;
+	// In full-screen the whole menu window carries its own opacity control;
+	// docked layouts keep the categories opacity for the window background. The
+	// alpha is built exactly like cats_alpha/apps_alpha so the live reload path
+	// is shared.
+	const bool is_fullscreen = (g_strcmp0(m_settings->layout_mode, "fullscreen") == 0);
+	const double window_alpha = is_fullscreen
+			? CLAMP(m_settings->full_screen_opacity, 0, 100) / 100.0
+			: cats_alpha;
 
 	gchar* css = g_strdup_printf(
 		".meowmenu { background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
@@ -2049,7 +2089,7 @@ void WhiskerMenu::Window::update_background_css()
 		".meowmenu treeview:focus-visible,"
 		".meowmenu iconview:focus-visible"
 		"{ outline: 1px solid @theme_selected_bg_color; outline-offset: -1px; }",
-		red, green, blue, cats_alpha,
+		red, green, blue, window_alpha,
 		red, green, blue, apps_alpha);
 
 	gtk_css_provider_load_from_data(m_css_provider, css, -1, nullptr);
@@ -2580,19 +2620,25 @@ void WhiskerMenu::Window::update_layout()
 		m_switch_loc = pres.switch_location;
 	}
 
-	// Handle showing username and profile
-	if (m_profile_shape != Settings::ProfileHidden)
-	{
-		gtk_widget_set_visible(m_profile->get_picture(), true);
-		gtk_widget_set_visible(m_profile->get_username(), true);
-		gtk_widget_set_visible(GTK_WIDGET(m_title_box), true);
-	}
-	else
-	{
-		gtk_widget_set_visible(m_profile->get_picture(), false);
-		gtk_widget_set_visible(m_profile->get_username(), false);
-		gtk_widget_set_visible(GTK_WIDGET(m_title_box), !m_layout_categories_alternate);
-	}
+	// Profile and session-command visibility. profile_position and
+	// commands_position are the authoritative hide signals; the legacy
+	// ProfileHidden shape is migrated to profile_position == "hidden" on upgrade
+	// and is no longer consulted here. The avatar + username follow the profile
+	// position; the whole session command box follows the commands position.
+	const bool profile_hidden  = (g_strcmp0(m_settings->profile_position, "hidden") == 0);
+	const bool commands_hidden = (g_strcmp0(m_settings->commands_position, "hidden") == 0);
+	const bool unified         = unified_bar_effective(*m_settings);
+
+	gtk_widget_set_visible(m_profile->get_picture(),  !profile_hidden);
+	gtk_widget_set_visible(m_profile->get_username(), !profile_hidden);
+	gtk_widget_set_visible(GTK_WIDGET(m_commands_box), !commands_hidden);
+
+	// Collapse the user/session row when both clusters are hidden in a docked
+	// layout (FR-003); keep it in unified-bar / full-screen where it carries the
+	// shared search row (FR-004).
+	gtk_widget_set_visible(GTK_WIDGET(m_title_box),
+			user_session_row_visible(unified, profile_hidden, commands_hidden,
+					m_layout_categories_alternate));
 
 	// Arrange horizontal order of profile picture, username, and commands
 	if (m_layout_ltr && m_layout_commands_alternate)
@@ -2827,9 +2873,10 @@ void WhiskerMenu::Window::update_layout()
 		gtk_widget_set_margin_start(GTK_WIDGET(m_search_entry), 0);
 		gtk_widget_set_margin_end(GTK_WIDGET(m_search_entry), 0);
 		gtk_box_pack_start(m_search_box, GTK_WIDGET(m_search_entry), TRUE, TRUE, 0);
-		// Restore username visibility and expand per the existing profile-shape rule.
+		// Restore username visibility per profile_position (the authoritative
+		// hide signal) and re-expand it for the docked row.
 		gtk_widget_set_visible(m_profile->get_username(),
-				m_profile_shape != Settings::ProfileHidden);
+				g_strcmp0(m_settings->profile_position, "hidden") != 0);
 		gtk_widget_set_hexpand(m_profile->get_username(), TRUE);
 		gtk_widget_set_visible(GTK_WIDGET(m_search_box), TRUE);
 		gtk_style_context_remove_class(title_ctx, "unified-bar");

--- a/panel-plugin/core/window.cpp
+++ b/panel-plugin/core/window.cpp
@@ -36,6 +36,7 @@
 #include "sidebar-layout.h"
 #include "theme-fallback.h"
 #include "user-session-layout.h"
+#include "window-frame.h"
 #include "ui/slot.h"
 #include "ui/switch-icons.h"
 #include "search/unified-bar.h"
@@ -306,10 +307,12 @@ WhiskerMenu::Window::Window(Settings* settings, Plugin* plugin) :
 
 	g_signal_connect(G_OBJECT(m_window), "delete-event", G_CALLBACK(&gtk_widget_hide_on_delete), nullptr);
 
-	// Create the border of the window
+	// Structural container only — the frame no longer carries a visible border.
+	// The single intentional window border is stroked along the rounded clip path
+	// in on_draw_event; a frame shadow here would draw a second, square outline
+	// that ignores the corner radius (the doubled/ghost line defect).
 	m_frame = GTK_FRAME(gtk_frame_new(nullptr));
-	GtkShadowType initial_shadow = (m_settings->corner_radius > 0) ? GTK_SHADOW_NONE : GTK_SHADOW_OUT;
-	gtk_frame_set_shadow_type(m_frame, initial_shadow);
+	gtk_frame_set_shadow_type(m_frame, GTK_SHADOW_NONE);
 	gtk_container_add(GTK_CONTAINER(m_window), GTK_WIDGET(m_frame));
 
 	// Create window contents stack
@@ -883,14 +886,10 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 						&& g_strcmp0(property, "/apps-opacity") != 0
 						&& g_strcmp0(property, "/full-screen-opacity") != 0)
 					return;
+				// The corner radius is applied entirely by re-clipping and
+				// re-stroking in on_draw_event; the redraw queued below picks up
+				// the new radius live. No frame-shadow toggle remains.
 				auto* self = static_cast<Window*>(user_data);
-				if (g_strcmp0(property, "/corner-radius") == 0 && self->m_frame)
-				{
-					const int r = CLAMP(static_cast<int>(self->m_settings->corner_radius), 0, 24);
-					gtk_frame_set_shadow_type(self->m_frame,
-						r > 0 ? GTK_SHADOW_NONE : GTK_SHADOW_OUT);
-				}
-
 				self->update_background_css();
 				self->on_screen_changed(GTK_WIDGET(self->m_window));
 				gtk_widget_queue_draw(GTK_WIDGET(self->m_window));
@@ -2044,6 +2043,14 @@ void WhiskerMenu::Window::update_background_css()
 	const int sep_r = (sep_luma < 128.0) ? CLAMP(red   + sep_step, 0, 255) : CLAMP(red   - sep_step, 0, 255);
 	const int sep_g = (sep_luma < 128.0) ? CLAMP(green + sep_step, 0, 255) : CLAMP(green - sep_step, 0, 255);
 	const int sep_b = (sep_luma < 128.0) ? CLAMP(blue  + sep_step, 0, 255) : CLAMP(blue  - sep_step, 0, 255);
+	// Publish the seed for on_draw_event: the single window border stroke reuses
+	// exactly this theme-derived colour, so the boundary keeps its previous hue
+	// even though it is now drawn once along the rounded path instead of as a
+	// per-region CSS outline.
+	m_separator_rgba.red   = sep_r / 255.0;
+	m_separator_rgba.green = sep_g / 255.0;
+	m_separator_rgba.blue  = sep_b / 255.0;
+	m_separator_rgba.alpha = 1.0;
 	// Resolve which absolute alpha each region receives for this render pass.
 	// The pure helper enforces the 0=transparent / 100=solid contract and the
 	// dual single-alpha model: docked => transparent window with each region
@@ -2059,18 +2066,45 @@ void WhiskerMenu::Window::update_background_css()
 			m_settings->apps_opacity,
 			m_settings->full_screen_opacity);
 
-	// The results outline only applies in docked mode. In full-screen the whole
-	// surface carries one alpha and the regions are transparent, so an outline
-	// there would draw a stray rectangle over an intentionally seamless menu.
-	gchar* apps_border = is_fullscreen
-			? g_strdup("")
-			: g_strdup_printf(
-				".meowmenu .applications-area"
-				"{ border: 1px solid rgba(%d, %d, %d, 1.0); }",
-				sep_r, sep_g, sep_b);
+	// Chrome/frame fill used by on_draw_event for the resizer ring: the theme
+	// background at the categories-region alpha, so the 6 px the resizer grid
+	// reserves around the content reads as part of the menu frame (same alpha as
+	// the search/title/commands strips) instead of showing the desktop through
+	// the transparent docked shell.
+	m_chrome_rgba.red   = red   / 255.0;
+	m_chrome_rgba.green = green / 255.0;
+	m_chrome_rgba.blue  = blue  / 255.0;
+	m_chrome_rgba.alpha = alphas.categories;
 
+	// NOTE: the results area no longer emits its own 1 px outline. The single
+	// intentional menu border is drawn once in on_draw_event along the rounded
+	// clip path (docked only); a per-region CSS border here would double that
+	// line and ignore the corner radius. Full-screen continues to show no
+	// outline at all (one seamless surface).
 	gchar* css = g_strdup_printf(
 		".meowmenu { background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
+		// NOTE: GTK wraps an undecorated, client-side-decorated toplevel in a
+		// `decoration` subnode that the active theme styles with a drop shadow
+		// (and often its own border-radius/border/margin). That node is painted
+		// outside everything on_draw_event controls, so it surfaces as a faint
+		// translucent halo sitting just beyond the single custom border — the
+		// ghost outline FR-003 forbids. Neutralise it so the only thing framing
+		// the menu is the one border stroked along the rounded clip path.
+		"window.meowmenu decoration,"
+		".meowmenu decoration"
+		"{ box-shadow: none; border: none; background: transparent;"
+		"  margin: 0; padding: 0; border-radius: 0; }"
+		// NOTE: the GtkFrame is a structural container only, but GTK3 still
+		// renders its themed `border` subnode and reserves that border/padding
+		// as an inset. That inset used to hide under the opaque pre-026 shell;
+		// the docked shell is now transparent, so the reserved ring shows the
+		// desktop through it as a band between the content and the single drawn
+		// border. Collapse the frame border/padding so the regions sit flush to
+		// the window edge where the border is stroked.
+		".meowmenu frame,"
+		".meowmenu frame > border"
+		"{ border: none; padding: 0; margin: 0;"
+		"  min-width: 0; min-height: 0; }"
 		// NOTE: .contents stays transparent on purpose — it is an ancestor of
 		// the applications area, so giving it a background would re-introduce a
 		// solid floor under the results region and defeat true-0 apps opacity.
@@ -2103,8 +2137,6 @@ void WhiskerMenu::Window::update_background_css()
 		".meowmenu .applications-area,"
 		".meowmenu .applications-area > *"
 		"{ background-image: none; background-color: rgba(%d, %d, %d, %.3f); }"
-		// Docked-only crisp 1 px results outline (empty string in full-screen).
-		"%s"
 		".meowmenu .category-button,"
 		".meowmenu .category-button *,"
 		".meowmenu .category-button image,"
@@ -2130,12 +2162,10 @@ void WhiskerMenu::Window::update_background_css()
 		"{ outline: 1px solid @theme_selected_bg_color; outline-offset: -1px; }",
 		red, green, blue, alphas.window,
 		red, green, blue, alphas.categories,
-		red, green, blue, alphas.apps,
-		apps_border);
+		red, green, blue, alphas.apps);
 
 	gtk_css_provider_load_from_data(m_css_provider, css, -1, nullptr);
 	g_free(css);
-	g_free(apps_border);
 }
 
 //-----------------------------------------------------------------------------
@@ -2161,6 +2191,94 @@ void WhiskerMenu::Window::on_screen_changed(GtkWidget* widget)
 
 //-----------------------------------------------------------------------------
 
+void WhiskerMenu::Window::apply_window_shape(int width, int height, int radius, bool composited)
+{
+	// Re-mask only when the silhouette actually changes; on_draw_event runs
+	// often and re-applying the shape every frame would thrash the window mask.
+	if (width == m_shape_width && height == m_shape_height
+			&& radius == m_shape_radius && composited == m_shape_composited)
+		return;
+	m_shape_width = width;
+	m_shape_height = height;
+	m_shape_radius = radius;
+	m_shape_composited = composited;
+
+	GtkWidget* widget = GTK_WIDGET(m_window);
+	if (!gtk_widget_get_realized(widget))
+		return;
+
+	// Square window: clear any prior mask so the toplevel is its full rectangle.
+	// Covers both corner radius 0 (FR-002) and the non-composited fallback
+	// (FR-006), which both render clean square corners.
+	if (radius <= 0 || !composited || width <= 0 || height <= 0)
+	{
+		gtk_widget_shape_combine_region(widget, nullptr);
+		return;
+	}
+
+	// Build a 1-bit (no anti-alias) rounded-rect mask matching the cairo clip in
+	// on_draw_event, then apply it as the window's bounding shape. The crisp mask
+	// edge sits one pixel outside the inset AA border stroke, so the border still
+	// reads smoothly while the hard mask removes the square native-window corner.
+	cairo_surface_t* mask = cairo_image_surface_create(CAIRO_FORMAT_A1, width, height);
+	cairo_t* mc = cairo_create(mask);
+	cairo_set_antialias(mc, CAIRO_ANTIALIAS_NONE);
+	cairo_set_operator(mc, CAIRO_OPERATOR_SOURCE);
+	cairo_set_source_rgba(mc, 0.0, 0.0, 0.0, 0.0);
+	cairo_paint(mc);
+	cairo_set_source_rgba(mc, 0.0, 0.0, 0.0, 1.0);
+	const double rr = radius;
+	cairo_new_path(mc);
+	cairo_arc(mc, rr,         rr,          rr, G_PI,       G_PI * 1.5);
+	cairo_arc(mc, width - rr, rr,          rr, G_PI * 1.5, G_PI * 2.0);
+	cairo_arc(mc, width - rr, height - rr, rr, 0.0,        G_PI * 0.5);
+	cairo_arc(mc, rr,         height - rr, rr, G_PI * 0.5, G_PI);
+	cairo_close_path(mc);
+	cairo_fill(mc);
+	cairo_destroy(mc);
+	cairo_surface_flush(mask);
+
+	cairo_region_t* region = gdk_cairo_region_create_from_surface(mask);
+	gtk_widget_shape_combine_region(widget, region);
+	cairo_region_destroy(region);
+	cairo_surface_destroy(mask);
+}
+
+//-----------------------------------------------------------------------------
+
+void WhiskerMenu::Window::fill_resizer_ring(cairo_t* cr, double width, double height)
+{
+	// The content vbox sits in the centre cell of the 3x3 resizer grid, inset by
+	// the drag-handle strip on every side. Fill that strip — the window rectangle
+	// minus the vbox rectangle — with the chrome background so the menu frame is
+	// continuous up to the border. The vbox itself is left untouched so the
+	// regions inside it (notably the apps area) keep their own alpha.
+	GtkAllocation va;
+	gtk_widget_get_allocation(GTK_WIDGET(m_vbox), &va);
+	if (va.width <= 0 || va.height <= 0)
+		return;
+
+	const double vx = va.x;
+	const double vy = va.y;
+	const double vw = va.width;
+	const double vh = va.height;
+
+	cairo_save(cr);
+	gdk_cairo_set_source_rgba(cr, &m_chrome_rgba);
+	if (vy > 0.0)                       // top strip
+		cairo_rectangle(cr, 0.0, 0.0, width, vy);
+	if (vy + vh < height)               // bottom strip
+		cairo_rectangle(cr, 0.0, vy + vh, width, height - (vy + vh));
+	if (vx > 0.0)                       // left strip (between top and bottom)
+		cairo_rectangle(cr, 0.0, vy, vx, vh);
+	if (vx + vw < width)                // right strip
+		cairo_rectangle(cr, vx + vw, vy, width - (vx + vw), vh);
+	cairo_fill(cr);
+	cairo_restore(cr);
+}
+
+//-----------------------------------------------------------------------------
+
 gboolean WhiskerMenu::Window::on_draw_event(GtkWidget* widget, cairo_t* cr)
 {
 	if (!gtk_widget_get_realized(widget))
@@ -2175,8 +2293,17 @@ gboolean WhiskerMenu::Window::on_draw_event(GtkWidget* widget, cairo_t* cr)
 	GdkScreen* screen = gtk_widget_get_screen(widget);
 	const bool enabled = gdk_screen_is_composited(screen);
 
-	// Build rounded-rect clip path (T040: corner-radius)
-	const double r = CLAMP(m_settings->corner_radius, 0, 24);
+	// Single shared corner-radius clamp [0,24] — the live property-changed
+	// handler queues a redraw that re-enters here, so the visible rounding can
+	// never diverge from the control's range.
+	const double r = meow::meowmenu_clamp_corner_radius(m_settings->corner_radius);
+
+	// Mask the toplevel window itself to the rounded silhouette. The cairo clip
+	// below only bounds windowless children; native-windowed regions ignore it
+	// and would paint a square corner outside the outline without this shape.
+	apply_window_shape(static_cast<int>(width), static_cast<int>(height),
+		static_cast<int>(r), enabled && m_supports_alpha);
+
 	auto clip_rounded = [&](cairo_t* c)
 	{
 		if (r > 0.0)
@@ -2194,6 +2321,32 @@ gboolean WhiskerMenu::Window::on_draw_event(GtkWidget* widget, cairo_t* cr)
 		}
 	};
 
+	// Path for the single border: the same silhouette as the clip, inset by half
+	// the 1 px line width so the whole stroke stays inside the surface (and inside
+	// the rounded clip at the corners) instead of being half-clipped at the edge.
+	const double border_width = 1.0;
+	auto border_path = [&](cairo_t* c)
+	{
+		const double inset = border_width / 2.0;
+		const double br = (r > inset) ? (r - inset) : 0.0;
+		cairo_new_path(c);
+		if (br > 0.0)
+		{
+			cairo_arc(c, inset + br,         inset + br,          br, G_PI,       G_PI * 1.5);
+			cairo_arc(c, width - inset - br, inset + br,          br, G_PI * 1.5, G_PI * 2.0);
+			cairo_arc(c, width - inset - br, height - inset - br, br, 0.0,        G_PI * 0.5);
+			cairo_arc(c, inset + br,         height - inset - br, br, G_PI * 0.5, G_PI);
+			cairo_close_path(c);
+		}
+		else
+		{
+			cairo_rectangle(c, inset, inset, width - border_width, height - border_width);
+		}
+	};
+
+	const bool is_fullscreen = (g_strcmp0(m_settings->layout_mode, "fullscreen") == 0);
+	GtkWidget* child = gtk_bin_get_child(GTK_BIN(widget));
+
 	if (enabled && m_supports_alpha)
 	{
 		// Erase the previous frame so pixels outside the rounded clip are transparent.
@@ -2202,28 +2355,67 @@ gboolean WhiskerMenu::Window::on_draw_event(GtkWidget* widget, cairo_t* cr)
 		cairo_paint(cr);
 		cairo_restore(cr);
 
-		cairo_surface_t* background = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-		cairo_t* cr_background = cairo_create(background);
-		cairo_set_operator(cr_background, CAIRO_OPERATOR_SOURCE);
-		gtk_render_background(context, cr_background, 0.0, 0.0, width, height);
-		cairo_destroy(cr_background);
-
-		cairo_set_source_surface(cr, background, 0.0, 0.0);
-		cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+		// Clip the ENTIRE window draw — shell background AND the propagated child
+		// regions — to the rounded silhouette. Post-026 the visible fill is painted
+		// by the regions (the docked shell is transparent), so the clip must bound
+		// the children for the radius to round what the user actually sees. At r==0
+		// this is a plain rectangular clip, so corners reduce to clean squares.
 		cairo_save(cr);
 		clip_rounded(cr);
 		cairo_clip(cr);
-		cairo_paint(cr);
+		gtk_render_background(context, cr, 0.0, 0.0, width, height);
+		// Docked only: fill the resizer ring with the chrome background. The 3x3
+		// resizer grid reserves a strip (the drag handles) around the content
+		// vbox; with the transparent docked shell that strip would otherwise show
+		// the desktop as a band between the border and the content. Painting only
+		// the ring — the window minus the content vbox — keeps the apps area's own
+		// alpha intact (no opaque floor under the results). Full-screen needs no
+		// fill: there the shell itself carries the single full-screen alpha.
+		if (!is_fullscreen && m_vbox)
+			fill_resizer_ring(cr, width, height);
+		if (child)
+			gtk_container_propagate_draw(GTK_CONTAINER(widget), child, cr);
 		cairo_restore(cr);
 
-		cairo_surface_destroy(background);
-	}
-	else
-	{
-		gtk_render_background(context, cr, 0.0, 0.0, width, height);
+		// Exactly one intentional border, following the same rounded path, drawn
+		// only docked + composited; full-screen reads as one seamless surface.
+		if (meow::meowmenu_frame_draws_border(is_fullscreen, m_supports_alpha))
+		{
+			cairo_save(cr);
+			cairo_set_line_width(cr, border_width);
+			gdk_cairo_set_source_rgba(cr, &m_separator_rgba);
+			border_path(cr);
+			cairo_stroke(cr);
+			cairo_restore(cr);
+		}
+
+		// We have drawn the background, the clipped children, and the border, so
+		// stop emission: the default handler must not re-draw the children
+		// unclipped (which would leave their square fill outside the rounded edge).
+		return GDK_EVENT_STOP;
 	}
 
-	return GDK_EVENT_PROPAGATE;
+	// Non-composited fallback (no RGBA visual): solid, square, no rounding
+	// (FR-006). Draw the shell background and propagate the children unclipped,
+	// then a single SQUARE border — gated on docked only (not the composited
+	// predicate, which requires supports_alpha), so a non-composited full-screen
+	// menu stays one seamless square surface with no outline.
+	gtk_render_background(context, cr, 0.0, 0.0, width, height);
+	if (!is_fullscreen && m_vbox)
+		fill_resizer_ring(cr, width, height);
+	if (child)
+		gtk_container_propagate_draw(GTK_CONTAINER(widget), child, cr);
+	if (!is_fullscreen)
+	{
+		cairo_save(cr);
+		cairo_set_line_width(cr, border_width);
+		gdk_cairo_set_source_rgba(cr, &m_separator_rgba);
+		cairo_rectangle(cr, border_width / 2.0, border_width / 2.0,
+			width - border_width, height - border_width);
+		cairo_stroke(cr);
+		cairo_restore(cr);
+	}
+	return GDK_EVENT_STOP;
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -295,6 +295,12 @@ private:
 	bool m_layout_search_alternate;
 	bool m_layout_commands_alternate;
 	bool m_layout_profile_alternate;
+	// Cached hidden state of the profile/commands clusters. Tracked separately
+	// from the *_alternate edge flags because a hidden ↔ visible transition can
+	// leave both edge flags unchanged; without these, show() would skip
+	// update_layout() and the restored element would never re-render.
+	bool m_layout_profile_hidden;
+	bool m_layout_commands_hidden;
 	bool m_layout_unified_bar;
 	int m_profile_shape;
 	bool m_supports_alpha;

--- a/panel-plugin/core/window.h
+++ b/panel-plugin/core/window.h
@@ -145,6 +145,36 @@ private:
 	void on_state_flags_changed(GtkWidget* widget);
 	void on_screen_changed(GtkWidget* widget);
 	gboolean on_draw_event(GtkWidget* widget, cairo_t* cr);
+
+	/* apply_window_shape:
+	 * @width:      current window allocation width in pixels.
+	 * @height:     current window allocation height in pixels.
+	 * @radius:     clamped corner radius in pixels (0 = square).
+	 * @composited: true when an RGBA visual / compositor is available.
+	 *
+	 * Masks the toplevel GdkWindow to the rounded silhouette so the corner
+	 * rounding clips EVERY child, including native-windowed regions (the apps
+	 * scrolledwindow/treeview) that composite straight onto the toplevel surface
+	 * and therefore ignore the cairo rounded clip in on_draw_event — they would
+	 * otherwise leave an opaque square corner outside the rounded outline. The
+	 * mask is reset (square, full rectangle) when radius is 0 or the desktop is
+	 * not composited. The (width, height, radius, composited) signature is cached
+	 * so a re-entrant draw only touches the shape when the silhouette changes.
+	 */
+	void apply_window_shape(int width, int height, int radius, bool composited);
+
+	/* fill_resizer_ring:
+	 * @cr:     the toplevel draw context.
+	 * @width:  window allocation width in pixels.
+	 * @height: window allocation height in pixels.
+	 *
+	 * Paints the strip the 3x3 resizer grid reserves around the content vbox
+	 * (the window rectangle minus the vbox rectangle) with the chrome background.
+	 * The docked window shell is transparent, so this prevents that strip from
+	 * showing the desktop as a band between the border and the content. The vbox
+	 * area is deliberately left unpainted so the apps region keeps its own alpha.
+	 */
+	void fill_resizer_ring(cairo_t* cr, double width, double height);
 	void update_background_css();
 	void check_scrollbar_needed();
 	void favorites_toggled();
@@ -304,6 +334,23 @@ private:
 	bool m_layout_unified_bar;
 	int m_profile_shape;
 	bool m_supports_alpha;
+	// Theme-derived separator colour (luminance-nudged from the menu background),
+	// computed once in update_background_css() and reused by on_draw_event so the
+	// single window border and the CSS region styling cannot diverge in colour.
+	GdkRGBA m_separator_rgba = { 0.0, 0.0, 0.0, 1.0 };
+	// Chrome/frame background (theme bg at the categories-region alpha), computed
+	// in update_background_css() and reused by on_draw_event to fill the resizer
+	// ring around the content. The docked window shell is transparent, so without
+	// this the 6 px the 3x3 resizer grid reserves around the content would show
+	// the desktop as a band between the border and the content.
+	GdkRGBA m_chrome_rgba = { 0.0, 0.0, 0.0, 1.0 };
+	// Cached signature of the last shape mask applied to the toplevel window, so
+	// apply_window_shape() re-masks only when the rounded silhouette changes.
+	// Initialised to -1 so the first draw always applies a shape.
+	int m_shape_width = -1;
+	int m_shape_height = -1;
+	int m_shape_radius = -1;
+	bool m_shape_composited = false;
 	bool m_child_has_focus;
 	bool m_resizing;
 };

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -23,6 +23,7 @@ plugin_sources = [
   'launcher/page.cpp',
   'places/places-item.cpp',
   'places/places-page.cpp',
+  'core/opacity-model.cpp',
   'core/plugin.cpp',
   'core/sidebar-layout.cpp',
   'core/theme-fallback.cpp',

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -29,6 +29,7 @@ plugin_sources = [
   'core/theme-fallback.cpp',
   'core/user-session-layout.cpp',
   'core/window-size-clamp.cpp',
+  'core/window-frame.cpp',
   'profile.cpp',
   'search/query.cpp',
   'launcher/recent-page.cpp',

--- a/panel-plugin/meson.build
+++ b/panel-plugin/meson.build
@@ -27,6 +27,7 @@ plugin_sources = [
   'core/plugin.cpp',
   'core/sidebar-layout.cpp',
   'core/theme-fallback.cpp',
+  'core/user-session-layout.cpp',
   'core/window-size-clamp.cpp',
   'profile.cpp',
   'search/query.cpp',

--- a/panel-plugin/presets/preset-io.cpp
+++ b/panel-plugin/presets/preset-io.cpp
@@ -43,7 +43,7 @@ struct PropDef
 
 static const char* SIDEBAR_DOMAIN[]         = { "left", "right", "top", "bottom" };
 static const char* SEARCHBAR_DOMAIN[]       = { "top", "bottom" };
-static const char* PROFILE_DOMAIN[]         = { "top", "bottom", "bottom-right", "hidden" };
+static const char* PROFILE_DOMAIN[]         = { "top", "bottom", "hidden" };
 static const char* COMMANDS_DOMAIN[]        = { "top-right", "bottom-right", "hidden" };
 static const char* GRID_DENSITY_DOMAIN[]    = { "low", "medium", "high" };
 static const char* LAYOUT_MODE_DOMAIN[]     = { "docked", "fullscreen" };
@@ -90,6 +90,28 @@ static const PropDef* find_prop_def(const char* name)
 			return &GOVERNED_PROPS[i];
 	}
 	return nullptr;
+}
+
+/* normalize_str_value:
+ * @key: the governed property name being parsed.
+ * @sv:  the raw string read from the preset file; ownership is taken.
+ *
+ * Applies forward-compatibility rewrites to a stored string before domain
+ * validation. The retired profile-position "bottom-right" rendered identically
+ * to "bottom" and is no longer a valid option, so a preset still carrying it is
+ * normalised to "bottom" on import rather than rejected.
+ *
+ * Returns: a newly-allocated string the caller owns (freed with g_free), or
+ *          NULL when @sv was NULL.
+ */
+static gchar* normalize_str_value(const char* key, gchar* sv)
+{
+	if (sv && strcmp(key, "profile-position") == 0 && strcmp(sv, "bottom-right") == 0)
+	{
+		g_free(sv);
+		return g_strdup("bottom");
+	}
+	return sv;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,7 +285,8 @@ ImportResult WhiskerMenu::import_user_preset(const std::string& file_path,
 			}
 			else // Str
 			{
-				gchar* sv = g_key_file_get_string(kf, "Settings", key, nullptr);
+				gchar* sv = normalize_str_value(key,
+					g_key_file_get_string(kf, "Settings", key, nullptr));
 				bool valid = false;
 				for (int di = 0; di < pd->domain_len; ++di)
 				{
@@ -475,7 +498,8 @@ static bool parse_preset_file_internal(const std::string& path, LayoutPreset& ou
 			}
 			else // Str
 			{
-				gchar* sv = g_key_file_get_string(kf, "Settings", key, nullptr);
+				gchar* sv = normalize_str_value(key,
+					g_key_file_get_string(kf, "Settings", key, nullptr));
 				bool valid = false;
 				for (int di = 0; di < pd->domain_len; ++di)
 				{

--- a/panel-plugin/settings-defaults.cpp
+++ b/panel-plugin/settings-defaults.cpp
@@ -82,13 +82,14 @@ void Settings::migrate_schema(bool marker, bool empty_channel)
 		}
 
 		// Write defaults for V1 properties not yet in the channel
+		// NOTE: /grid-columns and /grid-rows were orphaned config (no control, no
+		// consumer) and are removed; they are intentionally not seeded here, and
+		// the schema-v6 block deletes any pre-existing values.
 		struct { const char* prop; int val; } int_props[] = {
 			{ "/corner-radius",       0   },
 			{ "/panel-gap",           0   },
 			{ "/categories-opacity",  100 },
 			{ "/apps-opacity",        100 },
-			{ "/grid-columns",        4   },
-			{ "/grid-rows",           3   },
 		};
 		for (auto& p : int_props)
 		{
@@ -180,12 +181,14 @@ void Settings::migrate_schema(bool marker, bool empty_channel)
 	{
 		// Milestone 005 — Places mode keys. Seed defaults on first upgrade so
 		// existing installs see consistent values without re-applying a preset.
+		// NOTE: /places/show-metadata had no consumer and is removed; it is
+		// intentionally not seeded here, and the schema-v6 block deletes any
+		// pre-existing value.
 		struct { const char* prop; gboolean val; } bool_props[] = {
 			{ "/places/enabled",            FALSE },
 			{ "/places/history-enabled",    TRUE  },
 			{ "/places/favourites-enabled", TRUE  },
 			{ "/places/remember-last-mode", FALSE },
-			{ "/places/show-metadata",      FALSE },
 		};
 		for (auto& p : bool_props)
 		{
@@ -296,6 +299,31 @@ void Settings::migrate_schema(bool marker, bool empty_channel)
 		}
 
 		schema_version = 5;
+	}
+
+	if (schema_version < 6)
+	{
+		// Audit cleanup: drop orphaned/removed preference keys and normalise the
+		// redundant profile-position value. Resetting an absent key is a no-op,
+		// so this block is idempotent and touches only the named keys.
+		const char* removed_keys[] = {
+			"/grid-auto-size",
+			"/grid-columns",
+			"/grid-rows",
+			"/places/show-metadata",
+		};
+		for (const char* key : removed_keys)
+			xfconf_channel_reset_property(channel, key, FALSE);
+
+		// "bottom-right" rendered identically to "bottom" for the profile and is
+		// no longer offered; normalise any stored value so the combo never sees
+		// an option it cannot display.
+		gchar* profile_pos = xfconf_channel_get_string(channel, "/profile-position", nullptr);
+		if (g_strcmp0(profile_pos, "bottom-right") == 0)
+			xfconf_channel_set_string(channel, "/profile-position", "bottom");
+		g_free(profile_pos);
+
+		schema_version = 6;
 	}
 
 	// Back-fill the marker on every path (fresh, upgrade, or already-current

--- a/panel-plugin/settings-dialog.cpp
+++ b/panel-plugin/settings-dialog.cpp
@@ -193,6 +193,12 @@ SettingsDialog::~SettingsDialog()
 		m_unified_bar_slot = 0;
 	}
 
+	if (m_user_session_coupling_slot && m_settings && m_settings->channel)
+	{
+		g_signal_handler_disconnect(m_settings->channel, m_user_session_coupling_slot);
+		m_user_session_coupling_slot = 0;
+	}
+
 	for (auto command : m_commands)
 	{
 		delete command;

--- a/panel-plugin/settings-dialog.h
+++ b/panel-plugin/settings-dialog.h
@@ -94,6 +94,21 @@ private:
 	gulong m_unified_bar_slot = 0;
 	void apply_unified_bar_sensitivity();
 
+	// User/Session coupling (feature 027) — per-row greying of the Profile and
+	// Commands position combos plus reflecting any persisted auto-snap, driven
+	// by the shared normalize_user_session() helper. Refreshed whenever
+	// /layout-mode, /search-bar-position, /profile-position or /commands-position
+	// changes. The combo widget itself disambiguates Profile from Commands.
+	gulong m_user_session_coupling_slot = 0;
+	void apply_user_session_coupling();
+	void apply_user_session_combo_sensitivity(GtkCellLayout* layout,
+			GtkCellRenderer* cell, GtkTreeModel* model, GtkTreeIter* iter);
+	// GtkCellLayoutDataFunc trampoline: forwards to the member above (a static
+	// member can reach the private combo/settings state the C callback needs).
+	static void on_user_session_cell_data(GtkCellLayout* layout,
+			GtkCellRenderer* cell, GtkTreeModel* model, GtkTreeIter* iter,
+			gpointer data);
+
 private:
 	Settings* const m_settings;
 	Plugin* m_plugin;

--- a/panel-plugin/settings-dialog.h
+++ b/panel-plugin/settings-dialog.h
@@ -163,9 +163,6 @@ private:
 	// Behavior layout (T071)
 	GtkWidget* m_panel_gap = nullptr;
 	GtkWidget* m_layout_mode_combo = nullptr;
-	GtkWidget* m_grid_auto_size = nullptr;
-	GtkWidget* m_grid_columns = nullptr;
-	GtkWidget* m_grid_rows = nullptr;
 	GtkWidget* m_grid_density_combo = nullptr;
 	GtkWidget* m_grid_section = nullptr;
 

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -131,9 +131,6 @@ Settings::Settings(Plugin* plugin) :
 	profile_position(this, "/profile-position", "top"),
 	commands_position(this, "/commands-position", "top-right"),
 
-	grid_auto_size(this, "/grid-auto-size", true),
-	grid_columns(this, "/grid-columns", 4, 2, 10),
-	grid_rows(this, "/grid-rows", 3, 1, 8),
 	grid_density(this, "/grid-density", "medium"),
 
 	layout_mode(this, "/layout-mode", "docked"),
@@ -144,7 +141,6 @@ Settings::Settings(Plugin* plugin) :
 	places_favourite_sync(this, "/places/favourite-sync", "meowmenu"),
 	places_max_items(this, "/places/max-items", 20, 0, 30),
 	places_remember_last_mode(this, "/places/remember-last-mode", false),
-	places_show_metadata(this, "/places/show-metadata", false),
 	places_last_mode(this, "/places/last-mode", "apps"),
 	places_favourites(this, "/places/favourites", { }),
 	places_switch_show_icons(this, "/places/switch-show-icons", false)
@@ -510,9 +506,6 @@ void Settings::property_changed(const gchar* property, const GValue* value)
 			|| search_bar_position.load(property, value)
 			|| profile_position.load(property, value)
 			|| commands_position.load(property, value)
-			|| grid_auto_size.load(property, value)
-			|| grid_columns.load(property, value)
-			|| grid_rows.load(property, value)
 			|| grid_density.load(property, value)
 			|| layout_mode.load(property, value)
 			|| places_enabled.load(property, value)
@@ -521,7 +514,6 @@ void Settings::property_changed(const gchar* property, const GValue* value)
 			|| places_favourite_sync.load(property, value)
 			|| places_max_items.load(property, value)
 			|| places_remember_last_mode.load(property, value)
-			|| places_show_metadata.load(property, value)
 			|| places_last_mode.load(property, value)
 			|| places_favourites.load(property, value, reload)
 			|| places_switch_show_icons.load(property, value))

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -19,6 +19,7 @@
 
 #include "launcher/command.h"
 #include "core/plugin.h"
+#include "core/user-session-layout.h"
 #include "presets/preset.h"
 #include "search/search-action.h"
 #include "ui/slot.h"
@@ -435,6 +436,32 @@ void Settings::prevent_invalid()
 		else if (button_title.empty())
 		{
 			button_title = m_button_title_default;
+		}
+	}
+
+	// Normalise the Profile/Commands edge coupling toward the governing edge
+	// (the Profile edge when docked, the search-bar edge when full-screen) and
+	// persist any snapped value. The pure helper is the single authority shared
+	// with the renderer and the Preferences combos, so a stored or live-edited
+	// disallowed combination resolves the same way everywhere (FR-014/FR-017).
+	//
+	// NOTE: the snapped value is written back through the existing
+	// /profile-position and /commands-position keys (no new key) so the stored
+	// configuration and the rendered row stay in sync — reopening Preferences
+	// shows the resolved value. A "hidden" component is never un-hidden here;
+	// only the edge of an already-visible component moves.
+	{
+		const LayoutMode mode = (g_strcmp0(layout_mode, "fullscreen") == 0)
+				? LayoutMode::FullScreen : LayoutMode::Docked;
+		const UserSessionResolution res = normalize_user_session(
+				mode, search_bar_position, profile_position, commands_position);
+		if (res.profile_changed)
+		{
+			profile_position = res.profile_position;
+		}
+		if (res.commands_changed)
+		{
+			commands_position = res.commands_position;
 		}
 	}
 }

--- a/panel-plugin/settings.h
+++ b/panel-plugin/settings.h
@@ -436,9 +436,6 @@ public:
 	String commands_position;
 
 	// Layout Presets — grid (FullScreen mode)
-	Boolean grid_auto_size;
-	Integer grid_columns;
-	Integer grid_rows;
 	String  grid_density;
 
 	// Layout Presets — window mode
@@ -451,7 +448,6 @@ public:
 	String  places_favourite_sync;
 	Integer places_max_items;
 	Boolean places_remember_last_mode;
-	Boolean places_show_metadata;
 	String  places_last_mode;
 	StringList places_favourites;
 	// Render the Apps/Places switch as two themed icon buttons instead of text

--- a/panel-plugin/ui/properties/places.cpp
+++ b/panel-plugin/ui/properties/places.cpp
@@ -139,11 +139,6 @@ GtkWidget* SettingsDialog::init_places_tab()
 			m_settings->places_remember_last_mode);
 	gtk_grid_attach(behaviour_grid, remember_check, 0, 0, 2, 1);
 
-	GtkWidget* meta_check = gtk_check_button_new_with_mnemonic(_("Show item _metadata"));
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(meta_check),
-			m_settings->places_show_metadata);
-	gtk_grid_attach(behaviour_grid, meta_check, 0, 1, 2, 1);
-
 	// Sensitivity helpers (FR-037, FR-038).
 	auto refresh_sensitivity = [=]()
 	{
@@ -219,11 +214,6 @@ GtkWidget* SettingsDialog::init_places_tab()
 		[this](GtkToggleButton* btn)
 		{
 			m_settings->places_remember_last_mode = gtk_toggle_button_get_active(btn);
-		});
-	connect(meta_check, "toggled",
-		[this](GtkToggleButton* btn)
-		{
-			m_settings->places_show_metadata = gtk_toggle_button_get_active(btn);
 		});
 
 	return wrap_in_scrolled(GTK_WIDGET(page));

--- a/panel-plugin/ui/properties/user-session.cpp
+++ b/panel-plugin/ui/properties/user-session.cpp
@@ -21,6 +21,7 @@
 
 #include "ui/command-edit.h"
 #include "core/plugin.h"
+#include "core/user-session-layout.h"
 #include "settings.h"
 #include "ui/slot.h"
 
@@ -165,6 +166,43 @@ GtkWidget* SettingsDialog::init_user_session_tab()
 			refresh_customized_indicator();
 		});
 
+	// Per-row greying of the Profile/Commands position combos and live
+	// reflection of any persisted auto-snap, both driven by the shared coupling
+	// helper (FR-010/FR-017). A sensitivity data func on each combo's text
+	// renderer greys disallowed options without removing them; the property
+	// signal refreshes both whenever a governing key changes (e.g. a Profile
+	// edge flip snaps Commands, or a layout-mode switch re-couples both).
+	auto attach_sensitivity = [this](GtkWidget* combo)
+	{
+		GList* cells = gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(combo));
+		if (cells)
+		{
+			gtk_cell_layout_set_cell_data_func(GTK_CELL_LAYOUT(combo),
+					GTK_CELL_RENDERER(cells->data),
+					&SettingsDialog::on_user_session_cell_data, this, nullptr);
+			g_list_free(cells);
+		}
+	};
+	attach_sensitivity(m_profile_position_combo);
+	attach_sensitivity(m_commands_position_combo);
+
+	if (m_settings && m_settings->channel)
+	{
+		m_user_session_coupling_slot = g_signal_connect(m_settings->channel,
+			"property-changed",
+			G_CALLBACK(+[](XfconfChannel*, const gchar* property, const GValue*, gpointer data) -> void
+			{
+				if (g_strcmp0(property, "/layout-mode") != 0
+						&& g_strcmp0(property, "/search-bar-position") != 0
+						&& g_strcmp0(property, "/profile-position") != 0
+						&& g_strcmp0(property, "/commands-position") != 0)
+					return;
+				static_cast<SettingsDialog*>(data)->apply_user_session_coupling();
+			}), this);
+	}
+
+	apply_user_session_coupling();
+
 	// Unified-bar toggle (spec 004). Sits immediately under the
 	// commands-position combobox; live sensitivity drops in via
 	// apply_unified_bar_sensitivity(), which is invoked on any of the four
@@ -228,4 +266,101 @@ GtkWidget* SettingsDialog::init_user_session_tab()
 	}
 
 	return wrap_in_scrolled(GTK_WIDGET(page));
+}
+
+//-----------------------------------------------------------------------------
+
+/* SettingsDialog::on_user_session_cell_data:
+ *
+ * GtkCellLayoutDataFunc trampoline. @data is the owning SettingsDialog.
+ */
+void SettingsDialog::on_user_session_cell_data(GtkCellLayout* layout,
+		GtkCellRenderer* cell, GtkTreeModel* model, GtkTreeIter* iter, gpointer data)
+{
+	static_cast<SettingsDialog*>(data)
+			->apply_user_session_combo_sensitivity(layout, cell, model, iter);
+}
+
+//-----------------------------------------------------------------------------
+
+/* apply_user_session_combo_sensitivity:
+ * @layout: the combo whose row is being rendered (Profile or Commands).
+ * @cell:   the text renderer to set sensitive/insensitive.
+ * @model:  the GtkComboBoxText model (text in column 0, id in column 1).
+ * @iter:   the row being rendered.
+ *
+ * Greys a single combo row when the current layout coupling disallows that
+ * option (FR-010). The decision comes from the shared helper so the dialog can
+ * never disagree with the renderer; Hidden is always left selectable.
+ */
+void SettingsDialog::apply_user_session_combo_sensitivity(GtkCellLayout* layout,
+		GtkCellRenderer* cell, GtkTreeModel* model, GtkTreeIter* iter)
+{
+	gchar* id = nullptr;
+	// GtkComboBoxText keeps the option id in model column 1.
+	gtk_tree_model_get(model, iter, 1, &id, -1);
+
+	const LayoutMode mode = (g_strcmp0(m_settings->layout_mode, "fullscreen") == 0)
+			? LayoutMode::FullScreen : LayoutMode::Docked;
+	const UserSessionResolution res = normalize_user_session(mode,
+			m_settings->search_bar_position, m_settings->profile_position,
+			m_settings->commands_position);
+
+	bool enabled = true;
+	if (layout == GTK_CELL_LAYOUT(m_profile_position_combo))
+	{
+		if (g_strcmp0(id, "top") == 0)
+			enabled = res.profile_top_enabled;
+		else if (g_strcmp0(id, "bottom") == 0)
+			enabled = res.profile_bottom_enabled;
+		else
+			enabled = res.profile_hidden_enabled;
+	}
+	else
+	{
+		if (g_strcmp0(id, "top-right") == 0)
+			enabled = res.commands_top_right_enabled;
+		else if (g_strcmp0(id, "bottom-right") == 0)
+			enabled = res.commands_bottom_right_enabled;
+		else
+			enabled = res.commands_hidden_enabled;
+	}
+
+	g_object_set(cell, "sensitive", enabled, nullptr);
+	g_free(id);
+}
+
+//-----------------------------------------------------------------------------
+
+/* apply_user_session_coupling:
+ *
+ * Re-resolves the Profile/Commands coupling for the current layout and reflects
+ * the result in the two position combos: their active id is set to the resolved
+ * (possibly auto-snapped) value so the dialog matches what was persisted
+ * (FR-017), and both are redrawn so the per-row greying re-evaluates. Invoked at
+ * build time and whenever a governing key changes on the channel.
+ */
+void SettingsDialog::apply_user_session_coupling()
+{
+	if (!m_profile_position_combo || !m_commands_position_combo)
+		return;
+
+	const LayoutMode mode = (g_strcmp0(m_settings->layout_mode, "fullscreen") == 0)
+			? LayoutMode::FullScreen : LayoutMode::Docked;
+	const UserSessionResolution res = normalize_user_session(mode,
+			m_settings->search_bar_position, m_settings->profile_position,
+			m_settings->commands_position);
+
+	// Guard the programmatic active-id updates so the combos' "changed" handlers
+	// (which write back to Settings) do not re-fire for a value we are merely
+	// mirroring.
+	m_programmatic_update = true;
+	gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_profile_position_combo),
+			res.profile_position);
+	gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_commands_position_combo),
+			res.commands_position);
+	m_programmatic_update = false;
+
+	gtk_widget_queue_draw(m_profile_position_combo);
+	gtk_widget_queue_draw(m_commands_position_combo);
 }

--- a/panel-plugin/ui/properties/user-session.cpp
+++ b/panel-plugin/ui/properties/user-session.cpp
@@ -65,9 +65,12 @@ GtkWidget* SettingsDialog::init_user_session_tab()
 	gtk_grid_attach(profile_table, prof_pos_label, 0, 0, 1, 1);
 
 	m_profile_position_combo = gtk_combo_box_text_new();
+	// NOTE: no "bottom-right" entry — for the profile it renders identically to
+	// "bottom" (there is no horizontal end distinction), so it would be a
+	// duplicate option. A stored "bottom-right" is normalised to "bottom" on
+	// upgrade; "bottom-right" remains a distinct Commands Position value.
 	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(m_profile_position_combo), "top", _("Top"));
 	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(m_profile_position_combo), "bottom", _("Bottom"));
-	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(m_profile_position_combo), "bottom-right", _("Bottom Right"));
 	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(m_profile_position_combo), "hidden", _("Hidden"));
 	gtk_combo_box_set_active_id(GTK_COMBO_BOX(m_profile_position_combo),
 		static_cast<const gchar*>(m_settings->profile_position));

--- a/po/xfce4-meowmenu-plugin.pot
+++ b/po/xfce4-meowmenu-plugin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xfce4-meowmenu-plugin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-04 23:04+0200\n"
+"POT-Creation-Date: 2026-06-05 22:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: panel-plugin/launcher/applications-page.cpp:35
 #: panel-plugin/launcher/category.cpp:52
-#: panel-plugin/ui/properties/sidebar.cpp:285
+#: panel-plugin/ui/properties/sidebar.cpp:289
 msgid "All Applications"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgid "Failed to execute command \"%s\"."
 msgstr ""
 
 #: panel-plugin/launcher/favorites-page.cpp:37
-#: panel-plugin/ui/properties/sidebar.cpp:276
+#: panel-plugin/ui/properties/sidebar.cpp:280
 msgid "Favorites"
 msgstr ""
 
@@ -277,7 +277,7 @@ msgid "Based on Whisker Menu"
 msgstr ""
 
 #: panel-plugin/launcher/recent-page.cpp:37
-#: panel-plugin/ui/properties/sidebar.cpp:280
+#: panel-plugin/ui/properties/sidebar.cpp:284
 msgid "Recently Used"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgstr ""
 msgid "Sidebar"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:105 panel-plugin/core/window.cpp:558
-#: panel-plugin/core/window.cpp:2197
+#: panel-plugin/settings-dialog.cpp:105 panel-plugin/core/window.cpp:559
+#: panel-plugin/core/window.cpp:2321
 msgid "Places"
 msgstr ""
 
@@ -382,27 +382,36 @@ msgid "Unable to open the following url: %s"
 msgstr ""
 
 #. NOTE: fallback if initialize_file_presets() was not called or all files missing.
-#: panel-plugin/settings-dialog.cpp:687
+#: panel-plugin/settings-dialog.cpp:690
 msgid "Classic"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:688
+#: panel-plugin/settings-dialog.cpp:691
 msgid "Modern"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:689
+#: panel-plugin/settings-dialog.cpp:692
 msgid "Full Screen"
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:791
+#. NOTE: save_current_as_user_preset writes the snapshot under
+#. /presets/<uuid>/ (not the live keys) and sets
+#. current_preset_id to the new uuid, giving a truthful label
+#. the user can later rename or save over.
+#: panel-plugin/settings-dialog.cpp:719 panel-plugin/settings.cpp:411
+#: panel-plugin/settings-defaults.cpp:297
+msgid "Custom"
+msgstr ""
+
+#: panel-plugin/settings-dialog.cpp:812
 msgid "Render profile, search and session on a single horizontal row."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:793
+#: panel-plugin/settings-dialog.cpp:814
 msgid "This option requires the FullScreen layout."
 msgstr ""
 
-#: panel-plugin/settings-dialog.cpp:795
+#: panel-plugin/settings-dialog.cpp:816
 msgid ""
 "This option requires profile, search and session to be on the same end (all "
 "top or all bottom)."
@@ -560,85 +569,85 @@ msgstr ""
 msgid "Reset all settings to defaults?"
 msgstr ""
 
-#: panel-plugin/ui/properties/general.cpp:498
+#: panel-plugin/ui/properties/general.cpp:502
 msgid ""
 "FullScreen mode requires gtk-layer-shell on Wayland. The menu will open as a "
 "regular window instead."
 msgstr ""
 
-#: panel-plugin/ui/properties/general.cpp:520
+#: panel-plugin/ui/properties/general.cpp:524
 msgid "Panel plugin"
 msgstr ""
 
 #. Show panel button title
-#: panel-plugin/ui/properties/general.cpp:526
+#: panel-plugin/ui/properties/general.cpp:530
 msgid "Show panel button _title"
 msgstr ""
 
 #. Title entry
-#: panel-plugin/ui/properties/general.cpp:533
+#: panel-plugin/ui/properties/general.cpp:537
 msgid "T_itle:"
 msgstr ""
 
 #. Show panel button icon
-#: panel-plugin/ui/properties/general.cpp:570
+#: panel-plugin/ui/properties/general.cpp:574
 msgid "Show panel button _icon"
 msgstr ""
 
 #. Icon picker
-#: panel-plugin/ui/properties/general.cpp:577
+#: panel-plugin/ui/properties/general.cpp:581
 msgid "Ic_on:"
 msgstr ""
 
 #. Single-row panel layout
-#: panel-plugin/ui/properties/general.cpp:614
+#: panel-plugin/ui/properties/general.cpp:618
 msgid "Use a single panel _row"
 msgstr ""
 
-#: panel-plugin/ui/properties/general.cpp:638
+#: panel-plugin/ui/properties/general.cpp:642
 msgid "General menu settings"
 msgstr ""
 
 #. Layout mode
-#: panel-plugin/ui/properties/general.cpp:644
+#: panel-plugin/ui/properties/general.cpp:648
 msgid "_Layout mode:"
 msgstr ""
 
-#: panel-plugin/ui/properties/general.cpp:649
+#: panel-plugin/ui/properties/general.cpp:653
 msgid "Docked"
 msgstr ""
 
-#: panel-plugin/ui/properties/general.cpp:650
+#: panel-plugin/ui/properties/general.cpp:654
 msgid "FullScreen"
 msgstr ""
 
 #. Panel gap
-#: panel-plugin/ui/properties/general.cpp:679
+#: panel-plugin/ui/properties/general.cpp:683
 msgid "_Panel gap:"
 msgstr ""
 
 #. Menu width (enable-when-docked)
-#: panel-plugin/ui/properties/general.cpp:703
+#: panel-plugin/ui/properties/general.cpp:707
 msgid "Menu _width:"
 msgstr ""
 
 #. Menu height (enable-when-docked)
-#: panel-plugin/ui/properties/general.cpp:725
+#: panel-plugin/ui/properties/general.cpp:729
 msgid "Menu _height:"
 msgstr ""
 
 #. Corner radius
-#: panel-plugin/ui/properties/general.cpp:747
+#: panel-plugin/ui/properties/general.cpp:751
 msgid "_Corner radius:"
 msgstr ""
 
 #. Full-screen opacity (enable-when-fullscreen) — schema v2 key.
-#: panel-plugin/ui/properties/general.cpp:771
+#: panel-plugin/ui/properties/general.cpp:775
 msgid "F_ull-screen opacity:"
 msgstr ""
 
 #. Stay visible when focus is lost (FR-013: lives only in General).
-#: panel-plugin/ui/properties/general.cpp:795
+#: panel-plugin/ui/properties/general.cpp:799
 msgid "Stay _visible when focus is lost"
 msgstr ""
 
@@ -683,16 +692,12 @@ msgid "Maximum places _items:"
 msgstr ""
 
 #: panel-plugin/ui/properties/places.cpp:133
-#: panel-plugin/ui/properties/sidebar.cpp:243
+#: panel-plugin/ui/properties/sidebar.cpp:247
 msgid "Behaviour"
 msgstr ""
 
 #: panel-plugin/ui/properties/places.cpp:137
 msgid "_Remember last selected mode"
-msgstr ""
-
-#: panel-plugin/ui/properties/places.cpp:142
-msgid "Show item _metadata"
 msgstr ""
 
 #: panel-plugin/ui/properties/results-view.cpp:62
@@ -764,7 +769,7 @@ msgid "App _box opacity:"
 msgstr ""
 
 #: panel-plugin/ui/properties/search-bar.cpp:58
-#: panel-plugin/ui/properties/sidebar.cpp:173
+#: panel-plugin/ui/properties/sidebar.cpp:177
 msgid "Position"
 msgstr ""
 
@@ -772,15 +777,19 @@ msgstr ""
 msgid "_Search bar position:"
 msgstr ""
 
+#. NOTE: no "bottom-right" entry — for the profile it renders identically to
+#. "bottom" (there is no horizontal end distinction), so it would be a
+#. duplicate option. A stored "bottom-right" is normalised to "bottom" on
+#. upgrade; "bottom-right" remains a distinct Commands Position value.
 #: panel-plugin/ui/properties/search-bar.cpp:66
-#: panel-plugin/ui/properties/sidebar.cpp:184
-#: panel-plugin/ui/properties/user-session.cpp:68
+#: panel-plugin/ui/properties/sidebar.cpp:188
+#: panel-plugin/ui/properties/user-session.cpp:72
 msgid "Top"
 msgstr ""
 
 #: panel-plugin/ui/properties/search-bar.cpp:67
-#: panel-plugin/ui/properties/sidebar.cpp:185
-#: panel-plugin/ui/properties/user-session.cpp:69
+#: panel-plugin/ui/properties/sidebar.cpp:189
+#: panel-plugin/ui/properties/user-session.cpp:73
 msgid "Bottom"
 msgstr ""
 
@@ -894,43 +903,43 @@ msgid "Categ_ory icon size:"
 msgstr ""
 
 #. Sidebar opacity (renamed from "Category opacity"; enable-when-docked).
-#: panel-plugin/ui/properties/sidebar.cpp:140
+#: panel-plugin/ui/properties/sidebar.cpp:144
 msgid "_Sidebar opacity:"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:177
+#: panel-plugin/ui/properties/sidebar.cpp:181
 msgid "Sidebar _position:"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:182
+#: panel-plugin/ui/properties/sidebar.cpp:186
 msgid "Left"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:183
+#: panel-plugin/ui/properties/sidebar.cpp:187
 msgid "Right"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:247
+#: panel-plugin/ui/properties/sidebar.cpp:251
 msgid "Switch categories by _hovering"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:260
+#: panel-plugin/ui/properties/sidebar.cpp:264
 msgid "Sort ca_tegories"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:273
+#: panel-plugin/ui/properties/sidebar.cpp:277
 msgid "Default category"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:335
+#: panel-plugin/ui/properties/sidebar.cpp:339
 msgid "Recently used"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:339
+#: panel-plugin/ui/properties/sidebar.cpp:343
 msgid "Maximum _items:"
 msgstr ""
 
-#: panel-plugin/ui/properties/sidebar.cpp:360
+#: panel-plugin/ui/properties/sidebar.cpp:364
 msgid "Include _favorites in \"Recent\""
 msgstr ""
 
@@ -943,54 +952,53 @@ msgstr ""
 msgid "_Position:"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:70
-#: panel-plugin/ui/properties/user-session.cpp:142
-msgid "Bottom Right"
-msgstr ""
-
-#: panel-plugin/ui/properties/user-session.cpp:71
-#: panel-plugin/ui/properties/user-session.cpp:143
+#: panel-plugin/ui/properties/user-session.cpp:74
+#: panel-plugin/ui/properties/user-session.cpp:146
 msgid "Hidden"
 msgstr ""
 
 #. Avatar shape (sub-enabled when profile-position != hidden).
-#: panel-plugin/ui/properties/user-session.cpp:81
+#: panel-plugin/ui/properties/user-session.cpp:84
 msgid "Avatar _shape:"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:86
+#: panel-plugin/ui/properties/user-session.cpp:89
 msgid "Round Picture"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:87
+#: panel-plugin/ui/properties/user-session.cpp:90
 msgid "Square Picture"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:133
+#: panel-plugin/ui/properties/user-session.cpp:136
 msgid "Commands"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:136
+#: panel-plugin/ui/properties/user-session.cpp:139
 msgid "_Commands position:"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:141
+#: panel-plugin/ui/properties/user-session.cpp:144
 msgid "Top Right"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:170
+#: panel-plugin/ui/properties/user-session.cpp:145
+msgid "Bottom Right"
+msgstr ""
+
+#: panel-plugin/ui/properties/user-session.cpp:173
 msgid "Place profile, search and session on a single _line"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:201
+#: panel-plugin/ui/properties/user-session.cpp:204
 msgid "Show c_onfirmation dialog"
 msgstr ""
 
-#: panel-plugin/ui/properties/user-session.cpp:216
+#: panel-plugin/ui/properties/user-session.cpp:219
 msgid "Session commands"
 msgstr ""
 
-#: panel-plugin/settings.cpp:39 panel-plugin/core/window.cpp:2195
+#: panel-plugin/settings.cpp:39 panel-plugin/core/window.cpp:2319
 msgid "Applications"
 msgstr ""
 
@@ -1018,144 +1026,136 @@ msgstr ""
 msgid "Open URI"
 msgstr ""
 
-#: panel-plugin/settings.cpp:153
+#: panel-plugin/settings.cpp:150
 msgid "_Settings Manager"
 msgstr ""
 
-#: panel-plugin/settings.cpp:155
+#: panel-plugin/settings.cpp:152
 msgid "Failed to open settings manager."
 msgstr ""
 
-#: panel-plugin/settings.cpp:158
+#: panel-plugin/settings.cpp:155
 msgid "_Lock Screen"
 msgstr ""
 
-#: panel-plugin/settings.cpp:160
+#: panel-plugin/settings.cpp:157
 msgid "Failed to lock screen."
 msgstr ""
 
-#: panel-plugin/settings.cpp:163
+#: panel-plugin/settings.cpp:160
 msgid "Switch _User"
 msgstr ""
 
-#: panel-plugin/settings.cpp:165
+#: panel-plugin/settings.cpp:162
 msgid "Failed to switch user."
 msgstr ""
 
-#: panel-plugin/settings.cpp:168
+#: panel-plugin/settings.cpp:165
 msgid "Log _Out"
 msgstr ""
 
-#: panel-plugin/settings.cpp:170 panel-plugin/settings.cpp:205
+#: panel-plugin/settings.cpp:167 panel-plugin/settings.cpp:202
 msgid "Failed to log out."
 msgstr ""
 
-#: panel-plugin/settings.cpp:171
+#: panel-plugin/settings.cpp:168
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:172
+#: panel-plugin/settings.cpp:169
 #, c-format
 msgid "Logging out in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:175
+#: panel-plugin/settings.cpp:172
 msgid "_Restart"
 msgstr ""
 
-#: panel-plugin/settings.cpp:177
+#: panel-plugin/settings.cpp:174
 msgid "Failed to restart."
 msgstr ""
 
-#: panel-plugin/settings.cpp:178
+#: panel-plugin/settings.cpp:175
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:179
+#: panel-plugin/settings.cpp:176
 #, c-format
 msgid "Restarting computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:182
+#: panel-plugin/settings.cpp:179
 msgid "Shut _Down"
 msgstr ""
 
-#: panel-plugin/settings.cpp:184
+#: panel-plugin/settings.cpp:181
 msgid "Failed to shut down."
 msgstr ""
 
-#: panel-plugin/settings.cpp:185
+#: panel-plugin/settings.cpp:182
 msgid "Are you sure you want to shut down?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:186
+#: panel-plugin/settings.cpp:183
 #, c-format
 msgid "Turning off computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:189
+#: panel-plugin/settings.cpp:186
 msgid "Suspe_nd"
 msgstr ""
 
-#: panel-plugin/settings.cpp:191
+#: panel-plugin/settings.cpp:188
 msgid "Failed to suspend."
 msgstr ""
 
-#: panel-plugin/settings.cpp:192
+#: panel-plugin/settings.cpp:189
 msgid "Do you want to suspend to RAM?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:193
+#: panel-plugin/settings.cpp:190
 #, c-format
 msgid "Suspending computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:196
+#: panel-plugin/settings.cpp:193
 msgid "_Hibernate"
 msgstr ""
 
-#: panel-plugin/settings.cpp:198
+#: panel-plugin/settings.cpp:195
 msgid "Failed to hibernate."
 msgstr ""
 
-#: panel-plugin/settings.cpp:199
+#: panel-plugin/settings.cpp:196
 msgid "Do you want to suspend to disk?"
 msgstr ""
 
-#: panel-plugin/settings.cpp:200
+#: panel-plugin/settings.cpp:197
 #, c-format
 msgid "Hibernating computer in %d seconds."
 msgstr ""
 
-#: panel-plugin/settings.cpp:203
+#: panel-plugin/settings.cpp:200
 msgid "Log Ou_t..."
 msgstr ""
 
-#: panel-plugin/settings.cpp:208
+#: panel-plugin/settings.cpp:205
 msgid "_Edit Applications"
 msgstr ""
 
-#: panel-plugin/settings.cpp:210
+#: panel-plugin/settings.cpp:207
 msgid "Failed to launch menu editor."
 msgstr ""
 
-#: panel-plugin/settings.cpp:213
+#: panel-plugin/settings.cpp:210
 msgid "Edit _Profile"
 msgstr ""
 
-#: panel-plugin/settings.cpp:215
+#: panel-plugin/settings.cpp:212
 msgid "Failed to edit profile."
 msgstr ""
 
-#. NOTE: save_current_as_user_preset writes the snapshot under
-#. /presets/<uuid>/ (not the live keys) and sets
-#. current_preset_id to the new uuid, giving a truthful label
-#. the user can later rename or save over.
-#: panel-plugin/settings-defaults.cpp:272
-msgid "Custom"
-msgstr ""
-
-#: panel-plugin/core/window.cpp:557 panel-plugin/core/window.cpp:2195
+#: panel-plugin/core/window.cpp:558 panel-plugin/core/window.cpp:2319
 msgid "Apps"
 msgstr ""
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -352,12 +352,20 @@ test('switch_icons', test_switch_icons, timeout: 30)
 
 # test_user_session_row: headless coverage of the pure user/session-row
 # visibility decision mirrored from panel-plugin/core/window.cpp (both-hidden
-# collapse in docked layouts; shared row preserved in unified-bar/full-screen).
-test_user_session_row_sources = ['test_user_session_row.cpp']
+# collapse in docked layouts; shared row preserved in unified-bar/full-screen)
+# PLUS the normalize_user_session() coupling/normalisation contract — the docked
+# Profile↔Commands edge coupling, the full-screen search-bar↔both coupling, the
+# auto-snap direction, the per-option greying masks, and idempotency. The pure
+# helper translation unit is linked directly; no display or Settings is needed.
+test_user_session_row_sources = [
+  'test_user_session_row.cpp',
+  '..' / 'panel-plugin' / 'core' / 'user-session-layout.cpp',
+]
 
 test_user_session_row = executable(
   'test_user_session_row',
   test_user_session_row_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
   dependencies: [],
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -314,6 +314,24 @@ test_sidebar_layout = executable(
 
 test('sidebar_layout', test_sidebar_layout)
 
+# test_opacity_model: headless coverage of the pure percentage->alpha and
+# per-region alpha-assignment helper in panel-plugin/core/opacity-model.cpp
+# (the 0=transparent / 100=solid contract, no dead zone, no inter-region
+# compounding). GTK-free helper; no display.
+test_opacity_model_sources = [
+  'test_opacity_model.cpp',
+  '..' / 'panel-plugin' / 'core' / 'opacity-model.cpp',
+]
+
+test_opacity_model = executable(
+  'test_opacity_model',
+  test_opacity_model_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [],
+)
+
+test('opacity_model', test_opacity_model)
+
 # test_switch_icons: coverage of the Apps/Places icon-chain resolver in
 # panel-plugin/ui/switch-icons.cpp. Builds a synthetic on-disk icon theme so
 # the present/absent cases are deterministic; GtkIconTheme lookups need no

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -297,6 +297,24 @@ test_window_size_clamp = executable(
 
 test('window_size_clamp', test_window_size_clamp)
 
+# test_window_frame: headless coverage of the pure window-frame helpers in
+# panel-plugin/core/window-frame.cpp (radius clamp [0,24] + the composited
+# rounded-border predicate). Pulls only the GTK-free helper translation unit;
+# no display server, no GTK widgets.
+test_window_frame_sources = [
+  'test_window_frame.cpp',
+  '..' / 'panel-plugin' / 'core' / 'window-frame.cpp',
+]
+
+test_window_frame = executable(
+  'test_window_frame',
+  test_window_frame_sources,
+  include_directories: include_directories('..' / 'panel-plugin'),
+  dependencies: [],
+)
+
+test('window_frame', test_window_frame)
+
 # test_sidebar_layout: headless coverage of the pure layout-decision mapping in
 # panel-plugin/core/sidebar-layout.cpp (sidebar visibility, switch placement /
 # orientation, forced icon/name states). GTK-free helper; no display.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -331,3 +331,16 @@ test_switch_icons = executable(
 )
 
 test('switch_icons', test_switch_icons, timeout: 30)
+
+# test_user_session_row: headless coverage of the pure user/session-row
+# visibility decision mirrored from panel-plugin/core/window.cpp (both-hidden
+# collapse in docked layouts; shared row preserved in unified-bar/full-screen).
+test_user_session_row_sources = ['test_user_session_row.cpp']
+
+test_user_session_row = executable(
+  'test_user_session_row',
+  test_user_session_row_sources,
+  dependencies: [],
+)
+
+test('user_session_row', test_user_session_row)

--- a/tests/test_opacity_model.cpp
+++ b/tests/test_opacity_model.cpp
@@ -1,0 +1,156 @@
+/*
+ * Headless tests for the pure opacity model declared in
+ * panel-plugin/core/opacity-model.h. No GTK/GDK types are used; only the
+ * integer opacity percentages the helper consumes are fabricated.
+ *
+ * Asserts the rendering contract (C1..C3, C6) in
+ * .specify/specs/026-opacity-bugfix/contracts/opacity-rendering.md:
+ *   C1 — percentage->alpha mapping (endpoints, monotonicity, clamping, no gap)
+ *   C2 — per-mode region alpha assignment table
+ *   C3 — no compounding (each region's alpha is its single governing value)
+ *   C6 — default-appearance invariance (all controls at 100 -> active regions 1.0)
+ */
+
+#include "core/opacity-model.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+
+namespace
+{
+
+int g_failures = 0;
+
+#define CHECK(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			++g_failures; \
+		} \
+	} while (0)
+
+bool eq(double a, double b)
+{
+	return std::fabs(a - b) < 1e-9;
+}
+
+// C1: endpoints map exactly to the transparent/solid extremes.
+void c1_endpoints()
+{
+	CHECK(eq(meowmenu_opacity_alpha(0), 0.0));
+	CHECK(eq(meowmenu_opacity_alpha(100), 1.0));
+}
+
+// C1: strict monotonic increase across every integer step in [0, 100], so no
+// two neighbouring values collapse to the same alpha (no dead zone / floor).
+void c1_strict_monotonic_no_dead_zone()
+{
+	double prev = meowmenu_opacity_alpha(0);
+	for (int v = 1; v <= 100; ++v)
+	{
+		double cur = meowmenu_opacity_alpha(v);
+		CHECK(cur > prev);
+		prev = cur;
+	}
+}
+
+// C1: linearity at a representative interior point.
+void c1_linear_midpoint()
+{
+	CHECK(eq(meowmenu_opacity_alpha(50), 0.5));
+	CHECK(eq(meowmenu_opacity_alpha(25), 0.25));
+}
+
+// C1: out-of-range input is clamped, never extrapolated.
+void c1_clamping()
+{
+	CHECK(eq(meowmenu_opacity_alpha(-1), 0.0));
+	CHECK(eq(meowmenu_opacity_alpha(-1000), 0.0));
+	CHECK(eq(meowmenu_opacity_alpha(101), 1.0));
+	CHECK(eq(meowmenu_opacity_alpha(1000), 1.0));
+}
+
+// C2: docked mode -> transparent window, each region owns its own alpha.
+void c2_docked_assignment()
+{
+	OpacityRegionAlphas a = meowmenu_region_alphas(false, 80, 70, 100);
+	CHECK(eq(a.window, 0.0));
+	CHECK(eq(a.categories, 0.8));
+	CHECK(eq(a.apps, 0.7));
+}
+
+// C2: full-screen mode -> single window alpha, both regions transparent.
+void c2_fullscreen_assignment()
+{
+	OpacityRegionAlphas a = meowmenu_region_alphas(true, 80, 70, 50);
+	CHECK(eq(a.window, 0.5));
+	CHECK(eq(a.categories, 0.0));
+	CHECK(eq(a.apps, 0.0));
+}
+
+// C2: in full-screen the docked controls do not leak into any region, so the
+// whole surface reads at exactly alpha(full_screen_opacity).
+void c2_fullscreen_ignores_docked_controls()
+{
+	OpacityRegionAlphas a = meowmenu_region_alphas(true, 0, 100, 30);
+	CHECK(eq(a.window, 0.3));
+	CHECK(eq(a.categories, 0.0));
+	CHECK(eq(a.apps, 0.0));
+}
+
+// C3: no compounding — each active region's alpha equals exactly its single
+// governing value's alpha, never 1-(1-a)(1-b).
+void c3_no_compounding()
+{
+	OpacityRegionAlphas a = meowmenu_region_alphas(false, 50, 50, 100);
+	// If categories compounded onto apps the apps alpha would be
+	// 1-(1-0.5)(1-0.5) = 0.75; the contract requires the bare 0.5.
+	CHECK(eq(a.apps, 0.5));
+	CHECK(eq(a.categories, 0.5));
+}
+
+// C3: apps_opacity 0 in docked reaches a true transparent floor regardless of
+// the categories value — the reported "minimum limit" defect must be gone.
+void c3_apps_zero_is_true_zero()
+{
+	OpacityRegionAlphas a = meowmenu_region_alphas(false, 100, 0, 100);
+	CHECK(eq(a.apps, 0.0));
+	// The categories floor must not bleed into the apps region.
+	CHECK(eq(a.window, 0.0));
+}
+
+// C6: with every control at 100 the active-mode regions are fully solid in
+// both modes (default-appearance invariance).
+void c6_default_invariance()
+{
+	OpacityRegionAlphas docked = meowmenu_region_alphas(false, 100, 100, 100);
+	CHECK(eq(docked.categories, 1.0));
+	CHECK(eq(docked.apps, 1.0));
+
+	OpacityRegionAlphas full = meowmenu_region_alphas(true, 100, 100, 100);
+	CHECK(eq(full.window, 1.0));
+}
+
+} // namespace
+
+int main()
+{
+	c1_endpoints();
+	c1_strict_monotonic_no_dead_zone();
+	c1_linear_midpoint();
+	c1_clamping();
+	c2_docked_assignment();
+	c2_fullscreen_assignment();
+	c2_fullscreen_ignores_docked_controls();
+	c3_no_compounding();
+	c3_apps_zero_is_true_zero();
+	c6_default_invariance();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "%d check(s) failed\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("all opacity-model checks passed\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_preset_io.cpp
+++ b/tests/test_preset_io.cpp
@@ -43,7 +43,7 @@ static const std::vector<ShadowPropDef> SHADOW_SCHEMA = {
 	{ "sidebar-position",      PropKind::Str,  0,   0,    {"left","right","hidden"} },
 	{ "position-categories-horizontal", PropKind::Bool, 0, 0, {} },
 	{ "search-bar-position",   PropKind::Str,  0,   0,    {"top","bottom"} },
-	{ "profile-position",      PropKind::Str,  0,   0,    {"top","bottom","bottom-right","hidden"} },
+	{ "profile-position",      PropKind::Str,  0,   0,    {"top","bottom","hidden"} },
 	{ "commands-position",     PropKind::Str,  0,   0,    {"top-right","bottom-right","hidden"} },
 	{ "grid-density",          PropKind::Str,  0,   0,    {"low","medium","high"} },
 	{ "layout-mode",           PropKind::Str,  0,   0,    {"docked","fullscreen"} },

--- a/tests/test_properties_tabs.cpp
+++ b/tests/test_properties_tabs.cpp
@@ -131,7 +131,6 @@ const Row kPlacementGrid[] = {
 	//   /places/favourite-sync         — additionally gated by favourites-enabled.
 	//   /places/max-items              — page-gated by /places/enabled.
 	//   /places/remember-last-mode     — page-gated by /places/enabled.
-	//   /places/show-metadata          — page-gated by /places/enabled.
 	// NOTE: /places/last-mode and /places/favourites are Xfconf-backed
 	// runtime state, not Properties-dialog controls, so they are NOT on the
 	// placement grid (test models the dialog surface, not the schema).
@@ -141,7 +140,6 @@ const Row kPlacementGrid[] = {
 	{ "places/favourite-sync",       Tab::Places,      EnableWhen::PlacesFavouritesEnabled, false },
 	{ "places/max-items",            Tab::Places,      EnableWhen::PlacesEnabled,           false },
 	{ "places/remember-last-mode",   Tab::Places,      EnableWhen::PlacesEnabled,           false },
-	{ "places/show-metadata",        Tab::Places,      EnableWhen::PlacesEnabled,           false },
 };
 
 // Every Xfconf key documented in contracts/xfconf-keys.md that surfaces in
@@ -171,7 +169,7 @@ const char* const kRequiredKeys[] = {
 	// Places milestone-005 controls
 	"places/enabled", "places/history-enabled", "places/favourites-enabled",
 	"places/favourite-sync", "places/max-items",
-	"places/remember-last-mode", "places/show-metadata",
+	"places/remember-last-mode",
 };
 
 constexpr size_t kRowCount = sizeof(kPlacementGrid) / sizeof(kPlacementGrid[0]);

--- a/tests/test_schema_migration.cpp
+++ b/tests/test_schema_migration.cpp
@@ -23,7 +23,7 @@
 
 static int target_schema_version()
 {
-	return 5;
+	return 6;
 }
 
 static bool needs_migration(int current_schema_version)
@@ -49,6 +49,11 @@ static bool needs_v4_block(int current_schema_version)
 static bool needs_v5_block(int current_schema_version)
 {
 	return current_schema_version < 5;
+}
+
+static bool needs_v6_block(int current_schema_version)
+{
+	return current_schema_version < 6;
 }
 
 /* fresh_install_preset_id:
@@ -307,27 +312,29 @@ static int map_legacy_opacity(int has_categories_opacity, int legacy_menu_opacit
 
 static void test_schema_version_guard()
 {
-	assert(target_schema_version() == 5);
+	assert(target_schema_version() == 6);
 	assert(needs_migration(0) == true);
 	assert(needs_migration(1) == true);
 	assert(needs_migration(2) == true);
 	assert(needs_migration(3) == true);
 	assert(needs_migration(4) == true);
-	assert(needs_migration(5) == false);
+	assert(needs_migration(5) == true);
 	assert(needs_migration(6) == false);
 
-	// v0 → v5 walks through every block
+	// v0 → v6 walks through every block
 	assert(needs_v1_block(0) == true);
 	assert(needs_v2_block(0) == true);
 	assert(needs_v4_block(0) == true);
 	assert(needs_v5_block(0) == true);
+	assert(needs_v6_block(0) == true);
 
-	// v4 → v5 only runs the v5 block
-	assert(needs_v1_block(4) == false);
-	assert(needs_v2_block(4) == false);
-	assert(needs_v4_block(4) == false);
-	assert(needs_v5_block(4) == true);
+	// v5 → v6 only runs the v6 block
+	assert(needs_v1_block(5) == false);
+	assert(needs_v2_block(5) == false);
+	assert(needs_v4_block(5) == false);
 	assert(needs_v5_block(5) == false);
+	assert(needs_v6_block(5) == true);
+	assert(needs_v6_block(6) == false);
 }
 
 static void test_fresh_install_lands_on_modern()
@@ -454,6 +461,72 @@ static void test_idempotent_guard()
 	assert(needs_migration(target_schema_version()) == false);
 }
 
+// ---------------------------------------------------------------------------
+// schema-v6 cleanup mirror
+//
+// Mirrors the schema-v6 block in settings-defaults.cpp: a fixed set of removed
+// keys is reset, and a stored profile-position of "bottom-right" is normalised
+// to "bottom". Modelled over a tiny key set so the delete/keep/rewrite decisions
+// can be asserted without a live xfconfd.
+// ---------------------------------------------------------------------------
+
+/* v6_resets_key:
+ * @key: an xfconf property path.
+ *
+ * Returns: true iff the schema-v6 block deletes @key (orphaned/removed config).
+ */
+static bool v6_resets_key(const char* key)
+{
+	const char* removed[] = {
+		"/grid-auto-size",
+		"/grid-columns",
+		"/grid-rows",
+		"/places/show-metadata",
+	};
+	for (const char* k : removed)
+		if (std::strcmp(key, k) == 0)
+			return true;
+	return false;
+}
+
+/* v6_rewrite_profile_position:
+ * @value: the stored /profile-position string, or NULL when absent.
+ *
+ * Returns: the value to write, or NULL to leave the key untouched. Only the
+ * retired "bottom-right" is rewritten to "bottom"; every other value (and an
+ * absent key) is left as-is.
+ */
+static const char* v6_rewrite_profile_position(const char* value)
+{
+	if (value && std::strcmp(value, "bottom-right") == 0)
+		return "bottom";
+	return nullptr;
+}
+
+static void test_v6_cleanup()
+{
+	// The four orphaned/removed keys are deleted.
+	assert(v6_resets_key("/grid-auto-size") == true);
+	assert(v6_resets_key("/grid-columns") == true);
+	assert(v6_resets_key("/grid-rows") == true);
+	assert(v6_resets_key("/places/show-metadata") == true);
+
+	// Unrelated keys are left untouched (SC-005).
+	assert(v6_resets_key("/categories-opacity") == false);
+	assert(v6_resets_key("/profile-position") == false);
+	assert(v6_resets_key("/full-screen-opacity") == false);
+
+	// Redundant "bottom-right" profile value is normalised to "bottom".
+	const char* rewritten = v6_rewrite_profile_position("bottom-right");
+	assert(rewritten && std::strcmp(rewritten, "bottom") == 0);
+
+	// Every other profile value, and an absent key, is left as-is (no-op).
+	assert(v6_rewrite_profile_position("top") == nullptr);
+	assert(v6_rewrite_profile_position("bottom") == nullptr);
+	assert(v6_rewrite_profile_position("hidden") == nullptr);
+	assert(v6_rewrite_profile_position(nullptr) == nullptr);
+}
+
 // TODO-INTEGRATION: test_v0_to_v1_snapshot()
 //   Bring up a real xfconfd on XDG_CONFIG_HOME=/tmp/meow-test-XXXXXX,
 //   write a v0 property set (favorites, view-mode, menu-opacity=60),
@@ -483,5 +556,6 @@ int main()
 	test_idempotent_guard();
 	test_fresh_install_lands_on_modern();
 	test_upgrade_label_derivation();
+	test_v6_cleanup();
 	return 0;
 }

--- a/tests/test_user_session_row.cpp
+++ b/tests/test_user_session_row.cpp
@@ -1,0 +1,56 @@
+/*
+ * Unit tests for the user/session-row visibility decision.
+ *
+ * The decision is pure (four bools in, one bool out), so it can be tested in
+ * isolation without instantiating Settings or a GTK display. To keep this test
+ * dependency-free — matching the other tests/ — the decision body is mirrored
+ * here verbatim from user_session_row_visible() in panel-plugin/core/window.cpp.
+ * If the canonical implementation ever diverges, this test should be updated in
+ * lockstep.
+ *
+ * Covered behaviour:
+ *   - both clusters hidden in a docked layout collapses the row (FR-003);
+ *   - the shared row is preserved in unified-bar / full-screen (FR-004);
+ *   - a single visible cluster keeps the row.
+ */
+
+#include <cassert>
+
+/* Mirror of user_session_row_visible() in panel-plugin/core/window.cpp. */
+static bool user_session_row_visible(bool unified, bool profile_hidden,
+                                     bool commands_hidden, bool categories_alternate)
+{
+	if (unified)
+		return true;
+	if (!profile_hidden)
+		return true;
+	if (commands_hidden)
+		return false;
+	return !categories_alternate;
+}
+
+int main()
+{
+	// FR-003: docked, both profile and commands hidden → the row collapses,
+	// regardless of the category arrangement.
+	assert(user_session_row_visible(false, true, true, false) == false);
+	assert(user_session_row_visible(false, true, true, true)  == false);
+
+	// FR-004: unified-bar / full-screen always keeps the row (it carries the
+	// shared search cluster), even when both clusters are hidden.
+	assert(user_session_row_visible(true, true,  true,  false) == true);
+	assert(user_session_row_visible(true, true,  true,  true)  == true);
+	assert(user_session_row_visible(true, false, false, false) == true);
+
+	// A visible profile keeps the docked row no matter what commands do.
+	assert(user_session_row_visible(false, false, false, false) == true);
+	assert(user_session_row_visible(false, false, true,  false) == true);
+	assert(user_session_row_visible(false, false, true,  true)  == true);
+
+	// Profile hidden but commands visible (docked): the row stays, following the
+	// existing bottom-categories suppression.
+	assert(user_session_row_visible(false, true, false, false) == true);
+	assert(user_session_row_visible(false, true, false, true)  == false);
+
+	return 0;
+}

--- a/tests/test_user_session_row.cpp
+++ b/tests/test_user_session_row.cpp
@@ -14,19 +14,41 @@
  *   - a single visible cluster keeps the row.
  */
 
-#include <cassert>
+#include "core/user-session-layout.h"
 
-/* Mirror of user_session_row_visible() in panel-plugin/core/window.cpp. */
+#include <cassert>
+#include <cstring>
+
+using namespace WhiskerMenu;
+
+/* Mirror of user_session_row_visible() in panel-plugin/core/window.cpp. The
+ * canonical implementation collapses the docked row only when both clusters are
+ * hidden, independent of category placement (FR-001/004); this mirror is kept
+ * in lockstep with it. */
 static bool user_session_row_visible(bool unified, bool profile_hidden,
-                                     bool commands_hidden, bool categories_alternate)
+                                     bool commands_hidden, bool /*categories_alternate*/)
 {
 	if (unified)
 		return true;
-	if (!profile_hidden)
-		return true;
-	if (commands_hidden)
-		return false;
-	return !categories_alternate;
+	return !(profile_hidden && commands_hidden);
+}
+
+static bool seq(const char* a, const char* b)
+{
+	return std::strcmp(a, b) == 0;
+}
+
+/* check_vector: assert one normalize_user_session() input→output row from the
+ * coupling-matrix contract, including the *_changed expectations. */
+static void check_vector(LayoutMode mode, const char* search, const char* pin,
+                         const char* cin, const char* pout, const char* cout,
+                         bool pchanged, bool cchanged)
+{
+	UserSessionResolution r = normalize_user_session(mode, search, pin, cin);
+	assert(seq(r.profile_position, pout));
+	assert(seq(r.commands_position, cout));
+	assert(r.profile_changed == pchanged);
+	assert(r.commands_changed == cchanged);
 }
 
 int main()
@@ -47,10 +69,56 @@ int main()
 	assert(user_session_row_visible(false, false, true,  false) == true);
 	assert(user_session_row_visible(false, false, true,  true)  == true);
 
-	// Profile hidden but commands visible (docked): the row stays, following the
-	// existing bottom-categories suppression.
+	// FR-001/004: profile hidden but commands visible (docked) keeps the row —
+	// and it no longer depends on category placement (the old bug suppressed it
+	// when the category list sat at the bottom).
 	assert(user_session_row_visible(false, true, false, false) == true);
-	assert(user_session_row_visible(false, true, false, true)  == false);
+	assert(user_session_row_visible(false, true, false, true)  == true);
+
+	// ---------------------------------------------------------------------
+	// normalize_user_session() contract (coupling-matrix §A/§C/§D).
+	// Each row is "mode, search, profile_in, commands_in → profile_out,
+	// commands_out, profile_changed, commands_changed".
+	// ---------------------------------------------------------------------
+
+	// Docked — Commands edge follows the Profile edge (§A); Profile is free.
+	check_vector(LayoutMode::Docked, nullptr, "top",    "top-right",    "top",    "top-right",    false, false);
+	check_vector(LayoutMode::Docked, nullptr, "top",    "bottom-right", "top",    "top-right",    false, true);
+	check_vector(LayoutMode::Docked, nullptr, "bottom", "top-right",    "bottom", "bottom-right", false, true);
+	check_vector(LayoutMode::Docked, nullptr, "hidden", "bottom-right", "hidden", "bottom-right", false, false);
+	check_vector(LayoutMode::Docked, nullptr, "hidden", "hidden",       "hidden", "hidden",       false, false);
+
+	// FullScreen — both edges follow the search-bar edge (§C/§D).
+	check_vector(LayoutMode::FullScreen, "top",    "top",    "bottom-right", "top",    "top-right",    false, true);
+	check_vector(LayoutMode::FullScreen, "bottom", "top",    "top-right",    "bottom", "bottom-right", true,  true);
+	check_vector(LayoutMode::FullScreen, "bottom", "hidden", "top-right",    "hidden", "bottom-right", false, true);
+	check_vector(LayoutMode::FullScreen, "top",    "hidden", "hidden",       "hidden", "hidden",       false, false);
+
+	// Mask assertions.
+	{
+		// Docked Profile=top ⇒ Commands Bottom Right greyed; hidden always on.
+		UserSessionResolution d = normalize_user_session(LayoutMode::Docked, nullptr, "top", "top-right");
+		assert(d.commands_bottom_right_enabled == false);
+		assert(d.commands_top_right_enabled == true);
+		assert(d.profile_top_enabled == true && d.profile_bottom_enabled == true);
+		assert(d.profile_hidden_enabled && d.commands_hidden_enabled);
+
+		// FullScreen search=top ⇒ both bottom edges greyed; hidden always on.
+		UserSessionResolution f = normalize_user_session(LayoutMode::FullScreen, "top", "top", "top-right");
+		assert(f.profile_bottom_enabled == false);
+		assert(f.commands_bottom_right_enabled == false);
+		assert(f.profile_hidden_enabled && f.commands_hidden_enabled);
+	}
+
+	// Idempotency: feeding a resolved pair back in yields no further change.
+	{
+		UserSessionResolution once = normalize_user_session(LayoutMode::FullScreen, "bottom", "top", "top-right");
+		UserSessionResolution twice = normalize_user_session(LayoutMode::FullScreen, "bottom",
+				once.profile_position, once.commands_position);
+		assert(seq(twice.profile_position, once.profile_position));
+		assert(seq(twice.commands_position, once.commands_position));
+		assert(twice.profile_changed == false && twice.commands_changed == false);
+	}
 
 	return 0;
 }

--- a/tests/test_window_frame.cpp
+++ b/tests/test_window_frame.cpp
@@ -1,0 +1,82 @@
+/*
+ * Headless tests for the pure window-frame helpers declared in
+ * panel-plugin/core/window-frame.h. No GTK/GDK types are used; only the plain
+ * int radius and the two bool render-mode flags the helpers consume.
+ *
+ * Pins the radius clamp range [0,24] (contract C2/C7) and the composited
+ * rounded-border predicate (contract C3/C4/C7): the single rounded stroke is
+ * emitted iff (!is_fullscreen && supports_alpha).
+ */
+
+#include "core/window-frame.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using meow::meowmenu_clamp_corner_radius;
+using meow::meowmenu_frame_draws_border;
+
+namespace
+{
+
+int g_failures = 0;
+
+#define CHECK(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			++g_failures; \
+		} \
+	} while (0)
+
+// Radius below the range clamps up to 0; above the range clamps down to 24;
+// in-range values are the identity. This is the [0,24] bound the draw path and
+// the live handler must share.
+void radius_clamped_to_range()
+{
+	CHECK(meowmenu_clamp_corner_radius(-1) == 0);
+	CHECK(meowmenu_clamp_corner_radius(-100) == 0);
+	CHECK(meowmenu_clamp_corner_radius(0) == 0);
+	CHECK(meowmenu_clamp_corner_radius(12) == 12);
+	CHECK(meowmenu_clamp_corner_radius(24) == 24);
+	CHECK(meowmenu_clamp_corner_radius(25) == 24);
+	CHECK(meowmenu_clamp_corner_radius(1000) == 24);
+}
+
+// The clamp is monotonic: stepping the request up never lowers the result.
+void radius_clamp_is_monotonic()
+{
+	int prev = meowmenu_clamp_corner_radius(-5);
+	for (int r = -5; r <= 30; ++r)
+	{
+		const int cur = meowmenu_clamp_corner_radius(r);
+		CHECK(cur >= prev);
+		CHECK(cur >= 0 && cur <= 24);
+		prev = cur;
+	}
+}
+
+// The composited rounded-border stroke is emitted only docked + composited.
+void border_predicate_truth_table()
+{
+	CHECK(meowmenu_frame_draws_border(/*is_fullscreen=*/false, /*supports_alpha=*/true)  == true);
+	CHECK(meowmenu_frame_draws_border(/*is_fullscreen=*/true,  /*supports_alpha=*/true)  == false);
+	CHECK(meowmenu_frame_draws_border(/*is_fullscreen=*/false, /*supports_alpha=*/false) == false);
+	CHECK(meowmenu_frame_draws_border(/*is_fullscreen=*/true,  /*supports_alpha=*/false) == false);
+}
+
+} // namespace
+
+int main()
+{
+	radius_clamped_to_range();
+	radius_clamp_is_monotonic();
+	border_predicate_truth_table();
+
+	if (g_failures != 0)
+	{
+		std::fprintf(stderr, "test_window_frame: %d failure(s)\n", g_failures);
+		return EXIT_FAILURE;
+	}
+	std::printf("test_window_frame: ok\n");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Bugfix

- Fixed: setting Profile Position or Commands Position to "Hidden" now actually hides the avatar/username or session buttons in the menu (was stored but never applied).
- Fixed: when both Profile and Commands are set to "Hidden" in a docked layout, the entire user/session row collapses instead of leaving an empty strip.
- Fixed: Full-Screen opacity slider now applies live without restarting the panel.
- Fixed: Full-screen opacity now governs the entire menu surface, including the results/applications area (previously only the background was affected).
- Fixed: App-box opacity now reaches true full transparency at 0; there is no longer a minimum floor below which the slider has no effect.
- Fixed: All opacity controls (sidebar, app-box, full-screen) now honor a consistent 0 = fully transparent / 100 = fully solid contract.
- Fixed: In docked mode, setting app-box opacity to 0 no longer lets the categories/sidebar region bleed through as a solid floor behind the results area.
- Removed: "Show item metadata" toggle from the Places preferences tab — the option was stored but never used.
- Removed: redundant "Bottom Right" option from the Profile Position dropdown (it rendered identically to "Bottom"); Commands Position retains it as it is distinct there.
- Removed: orphaned grid layout settings (auto-size, columns, rows) that were stored but had no effect.
- Migration: upgrading from a previous configuration automatically cleans the stored keys for all removed settings and rewrites "bottom-right" profile position to "bottom" (schema v6).

## Known Issues
- Session Buttons: when Profile Icon is hidden, Session Buttons are in the middle of the panel (despite Top Right or Bottom Right setting)
- Custom Preset: cannot be saved/renamed/imported (major issue to be fixed in the following release)

